### PR TITLE
Remove references to NIOSSL on iOS, tvOS, watchOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 
 import PackageDescription
 
@@ -21,7 +21,7 @@ let package = Package(
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
             .product(name: "NIOWebSocket", package: "swift-nio"),
-            .product(name: "NIOSSL", package: "swift-nio-ssl"),
+            .product(name: "NIOSSL", package: "swift-nio-ssl", condition: .when(platforms: [.linux, .macOS])),
             .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
         ]),
         .target(name: "CCoreMQTT", dependencies: []),

--- a/Sources/MQTTNIO/MQTTClient.swift
+++ b/Sources/MQTTNIO/MQTTClient.swift
@@ -5,7 +5,9 @@ import Network
 #endif
 import NIO
 import NIOConcurrencyHelpers
+#if canImport(NIOSSL)
 import NIOSSL
+#endif
 import NIOTransportServices
 
 /// Swift NIO MQTT Client
@@ -105,12 +107,14 @@ final public class MQTTClient {
         switch eventLoopGroupProvider {
         case .createNew:
             #if canImport(Network)
-            if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *),
-               case .niossl = configuration.tlsConfiguration {
-                    self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-                } else {
-                    self.eventLoopGroup = NIOTSEventLoopGroup()
-                }
+            switch configuration.tlsConfiguration {
+            #if canImport(NIOSSL)
+            case .niossl:
+                self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            #endif
+            case .ts, .none:
+                self.eventLoopGroup = NIOTSEventLoopGroup()
+            }
             #else
                 self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
             #endif

--- a/Sources/MQTTNIO/MQTTConfiguration.swift
+++ b/Sources/MQTTNIO/MQTTConfiguration.swift
@@ -1,5 +1,7 @@
 import NIO
+#if canImport(NIOSSL)
 import NIOSSL
+#endif
 
 extension MQTTClient {
     /// Enum for different TLS Configuration types. The TLS Configuration type to use if defined by the EventLoopGroup the
@@ -7,7 +9,9 @@ extension MQTTClient {
     /// It is recommended on iOS you use NIO Transport Services.
     public enum TLSConfigurationType {
         /// NIOSSL TLS configuration
+        #if canImport(NIOSSL)
         case niossl(TLSConfiguration)
+        #endif
         #if canImport(Network)
         /// NIO Transport Serviecs TLS configuration
         case ts(TSTLSConfiguration)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ version: "3.3"
 
 services:
   test:
-    image: swift:5.1
+    image: swift:5.3
     working_dir: /mqtt-nio
     volumes:
       - .:/mqtt-nio


### PR DESCRIPTION
Should be using NIOTransportServices on these platforms
Also means watchOS targets can be uploaded