### PR TITLE
Added MQTTUnhandledPacketHandler

### DIFF
--- a/Sources/MQTTNIO/MQTTChannelHandlers.swift
+++ b/Sources/MQTTNIO/MQTTChannelHandlers.swift
@@ -74,7 +74,7 @@ struct ByteToMQTTMessageDecoder: ByteToMessageDecoder {
                 let disconnectMessage = try MQTTDisconnectPacket.read(version: self.client.configuration.version, from: packet)
                 let ack = MQTTAckV5(reason: disconnectMessage.reason, properties: disconnectMessage.properties)
                 context.fireErrorCaught(MQTTError.serverDisconnection(ack))
-                message = disconnectMessage
+                return .continue
             case .AUTH:
                 message = try MQTTAuthPacket.read(version: self.client.configuration.version, from: packet)
             default:

--- a/Sources/MQTTNIO/MQTTTask.swift
+++ b/Sources/MQTTNIO/MQTTTask.swift
@@ -50,6 +50,8 @@ final class MQTTTaskHandler: ChannelInboundHandler, RemovableChannelHandler {
                     self.timeoutTask?.cancel()
                     self.task.succeed(response)
                 }
+            } else {
+                context.fireChannelRead(data)
             }
         } catch {
             self.errorCaught(context: context, error: error)
@@ -76,6 +78,31 @@ final class MQTTTaskHandler: ChannelInboundHandler, RemovableChannelHandler {
             }
         } else {
             self.timeoutTask = nil
+        }
+    }
+}
+
+/// If packet reaches this handler then it was never dealt with by a task
+final class MQTTUnhandledPacketHandler: ChannelInboundHandler {
+    typealias InboundIn = MQTTPacket
+    let client: MQTTClient
+
+    init(client: MQTTClient) {
+        self.client = client
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        // we only send response to v5 server
+        guard client.configuration.version == .v5_0 else { return }
+        guard let connection = client.connection else { return }
+        let response = self.unwrapInboundIn(data)
+        switch response.type {
+        case .PUBREC:
+            _ = connection.sendMessageNoWait(MQTTPubAckPacket(type: .PUBREL, packetId: response.packetId, reason: .packetIdentifierNotFound))
+        case .PUBREL:
+            _ = connection.sendMessageNoWait(MQTTPubAckPacket(type: .PUBCOMP, packetId: response.packetId, reason: .packetIdentifierNotFound))
+        default:
+            break
         }
     }
 }


### PR DESCRIPTION
To deal with unhandled PUBREC/PUBREL packets. V5 requires you to pass back a packetIdentifierNotFound reason