### PR TITLE
Only use NIOSSL on macOS and Linux (#101)

### DIFF
--- a/Sources/MQTTNIO/MQTTClient.swift
+++ b/Sources/MQTTNIO/MQTTClient.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the MQTTNIO project
 //
-// Copyright (c) 2020-2021 Adam Fowler
+// Copyright (c) 2020-2022 Adam Fowler
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -121,7 +121,8 @@ public final class MQTTClient {
         case .createNew:
             #if canImport(Network)
             switch configuration.tlsConfiguration {
-            #if canImport(NIOSSL)
+            // This should use canImport(NIOSSL), will change when it works with SwiftUI previews.
+            #if os(macOS) || os(Linux)
             case .niossl:
                 self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
             #endif

--- a/Sources/MQTTNIO/MQTTConfiguration.swift
+++ b/Sources/MQTTNIO/MQTTConfiguration.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the MQTTNIO project
 //
-// Copyright (c) 2020-2021 Adam Fowler
+// Copyright (c) 2020-2022 Adam Fowler
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -28,7 +28,8 @@ extension MQTTClient {
     /// It is recommended on iOS you use NIO Transport Services.
     public enum TLSConfigurationType {
         /// NIOSSL TLS configuration
-        #if canImport(NIOSSL)
+        // This should use canImport(NIOSSL), will change when it works with SwiftUI previews.
+        #if os(macOS) || os(Linux)
         case niossl(TLSConfiguration)
         #endif
         #if canImport(Network)

--- a/Sources/MQTTNIO/MQTTConnection.swift
+++ b/Sources/MQTTNIO/MQTTConnection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the MQTTNIO project
 //
-// Copyright (c) 2020-2021 Adam Fowler
+// Copyright (c) 2020-2022 Adam Fowler
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -96,7 +96,8 @@ final class MQTTConnection {
             switch client.configuration.tlsConfiguration {
             case .ts(let config):
                 options = try config.getNWProtocolTLSOptions()
-            #if canImport(NIOSSL)
+            // This should use canImport(NIOSSL), will change when it works with SwiftUI previews.
+            #if os(macOS) || os(Linux)
             case .niossl:
                 throw MQTTError.wrongTLSConfig
             #endif
@@ -112,7 +113,8 @@ final class MQTTConnection {
             return bootstrap
         }
         #endif
-        #if canImport(NIOSSL) // canImport(Network)
+        // This should use canImport(NIOSSL), will change when it works with SwiftUI previews.
+        #if os(macOS) || os(Linux) // canImport(Network)
         if let clientBootstrap = ClientBootstrap(validatingGroup: client.eventLoopGroup) {
             let tlsConfiguration: TLSConfiguration
             switch client.configuration.tlsConfiguration {

--- a/Sources/MQTTNIO/TSTLSConfiguration.swift
+++ b/Sources/MQTTNIO/TSTLSConfiguration.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the MQTTNIO project
 //
-// Copyright (c) 2020-2021 Adam Fowler
+// Copyright (c) 2020-2022 Adam Fowler
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -98,7 +98,8 @@ public struct TSTLSConfiguration {
         /// Create certificate array from already loaded SecCertificate array
         public static func certificates(_ secCertificates: [SecCertificate]) -> Self { .init(certificates: secCertificates) }
 
-        #if canImport(NIOSSL)
+        // This should use canImport(NIOSSL), will change when it works with SwiftUI previews.
+        #if os(macOS) || os(Linux)
         /// Create certificate array from PEM file
         public static func pem(_ filename: String) throws -> Self {
             let certificates = try NIOSSLCertificate.fromPEMFile(filename)


### PR DESCRIPTION
When building for SwiftUI Previews, checking if `NIOSSL` is available will succeed, despite the package has been configured to only link on macOS and Linux. This results in link errors which break SwiftUI Previews.