### PR TITLE
Support Unix Domain Socket connections

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: swift:5.9
     volumes:
       - ..:/workspace
+      - mosquitto-socket:/workspace/mosquitto/socket
     depends_on:
       - mosquitto
     environment:
@@ -18,8 +19,12 @@ services:
     volumes:
       - ../mosquitto/config:/mosquitto/config
       - ../mosquitto/certs:/mosquitto/certs
+      - mosquitto-socket:/mosquitto/socket
     ports:
       - "1883:1883"
       - "8883:8883"
       - "8080:8080"
       - "8081:8081"
+
+volumes:
+  mosquitto-socket:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,4 @@
-# run this with docker-compose -f docker/docker-compose.yml run test
+# run this with: docker-compose -f docker-compose.yml run test
 version: "3.3"
 
 services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
         volumes:
           - ${{ github.workspace }}/mosquitto/config:/mosquitto/config
           - ${{ github.workspace }}/mosquitto/certs:/mosquitto/certs
+          - ${{ github.workspace }}/mosquitto/socket:/mosquitto/socket
 
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ MQTTNIO is a Swift NIO based implementation of a MQTT client. It supports
 - WebSocket connections
 - Posix sockets
 - Apple's Network framework via [NIOTransportServices](https://github.com/apple/swift-nio-transport-services) (required for iOS).
+- Unix domain sockets
 
 You can find documentation for MQTTNIO
 [here](https://swift-server-community.github.io/mqtt-nio/documentation/mqttnio/). There is also a sample demonstrating the use MQTTNIO in an iOS app found [here](https://github.com/adam-fowler/EmCuTeeTee)

--- a/Sources/MQTTNIO/MQTTClient.swift
+++ b/Sources/MQTTNIO/MQTTClient.swift
@@ -141,6 +141,30 @@ public final class MQTTClient {
         self.inflight = .init()
     }
 
+    /// Create MQTT client
+    /// - Parameters:
+    ///   - unixSocketPath: Path to unix socket of MQTT broker
+    ///   - identifier: Client identifier. This must be unique
+    ///   - eventLoopGroupProvider: EventLoopGroup to run on
+    ///   - logger: Logger client should use
+    ///   - configuration: Configuration of client
+    public convenience init(
+        unixSocketPath: String,
+        identifier: String,
+        eventLoopGroupProvider: NIOEventLoopGroupProvider,
+        logger: Logger? = nil,
+        configuration: Configuration = Configuration()
+    ) {
+        self.init(
+            host: unixSocketPath,
+            port: 0,
+            identifier: identifier,
+            eventLoopGroupProvider: eventLoopGroupProvider,
+            logger: logger,
+            configuration: configuration
+        )
+    }
+
     deinit {
         guard isShutdown.load(ordering: .relaxed) else {
             preconditionFailure("Client not shut down before the deinit. Please call client.syncShutdownGracefully() when no longer needed.")

--- a/Sources/MQTTNIO/MQTTNIO.docc/mqttnio-connections.md
+++ b/Sources/MQTTNIO/MQTTNIO.docc/mqttnio-connections.md
@@ -34,16 +34,17 @@ On macOS and iOS you can use the NIO Transport Services library (NIOTS) and Appl
 
 ## Unix Domain Sockets
 
-MQTT NIO can connect to a local MQTT broker via a Unix Domain Socket. Specifying `port: 0` causes `host` string to be interpreted as a path to a local unix domain socket instead of as a hostname or IP address.
+MQTT NIO can connect to a local MQTT broker via a Unix Domain Socket.
 
 ```swift
 let client = MQTTClient(
-    host: "/path/to/broker.socket",
-    port: 0,
+    unixSocketPath: "/path/to/broker.socket",
     identifier: "UDSClient",
     eventLoopGroupProvider: .createNew
 )
 ```
+
+Under the hood, `MQTTClient.port` will be 0 and `MQTTClient.host` will be the specified unix socket path when connecting to a unix socket.
 
 Note that mosquitto supports listening on a unix domain socket. This can be enabled by adding a `listener` option to the mosquitto config.
 

--- a/Sources/MQTTNIO/MQTTNIO.docc/mqttnio-connections.md
+++ b/Sources/MQTTNIO/MQTTNIO.docc/mqttnio-connections.md
@@ -1,6 +1,6 @@
 # Connections
 
-Support for TLS and WebSockets.
+Support for TLS, WebSockets, and Unix Domain Sockets.
 
 ## TLS
 
@@ -31,3 +31,22 @@ MQTT also supports Web Socket connections. Provide a `WebSocketConfiguration` wh
 ## NIO Transport Services
 
 On macOS and iOS you can use the NIO Transport Services library (NIOTS) and Apple's `Network.framework` for communication with the MQTT broker. If you don't provide an `eventLoopGroup` or a `TLSConfigurationType` then this is the default for both platforms. If you do provide either of these then the library will base it's decision on whether to use NIOTS or NIOSSL on what you provide. Provide a `MultiThreadedEventLoopGroup` or `NIOSSL.TLSConfiguration` and the client will use NIOSSL. Provide a `NIOTSEventLoopGroup` or `TSTLSConfiguration` and the client will use NIOTS. If you provide a `MultiThreadedEventLoopGroup` and a `TSTLSConfiguration` then the client will throw an error. If you are running on iOS you should always choose NIOTS.
+
+## Unix Domain Sockets
+
+MQTT NIO can connect to a local MQTT broker via a Unix Domain Socket. Specifying `port: 0` causes `host` string to be interpreted as a path to a local unix domain socket instead of as a hostname or IP address.
+
+```swift
+let client = MQTTClient(
+    host: "/path/to/broker.socket",
+    port: 0,
+    identifier: "UDSClient",
+    eventLoopGroupProvider: .createNew
+)
+```
+
+Note that mosquitto supports listening on a unix domain socket. This can be enabled by adding a `listener` option to the mosquitto config.
+
+```
+listener 0 /path/to/broker.socket
+```

--- a/Tests/MQTTNIOTests/MQTTNIOTests.swift
+++ b/Tests/MQTTNIOTests/MQTTNIOTests.swift
@@ -148,8 +148,7 @@ final class MQTTNIOTests: XCTestCase {
 
     func testUnixDomainConnect() throws {
         let client = MQTTClient(
-            host: MQTTNIOTests.rootPath + "/mosquitto/socket/mosquitto.sock",
-            port: 0,
+            unixSocketPath: MQTTNIOTests.rootPath + "/mosquitto/socket/mosquitto.sock",
             identifier: "testUnixDomainConnect",
             eventLoopGroupProvider: .createNew,
             logger: self.logger,

--- a/Tests/MQTTNIOTests/MQTTNIOTests.swift
+++ b/Tests/MQTTNIOTests/MQTTNIOTests.swift
@@ -146,6 +146,21 @@ final class MQTTNIOTests: XCTestCase {
     }
     #endif
 
+    func testUnixDomainConnect() throws {
+        let client = MQTTClient(
+            host: MQTTNIOTests.rootPath + "/mosquitto/socket/mosquitto.sock",
+            port: 0,
+            identifier: "testUnixDomainConnect",
+            eventLoopGroupProvider: .createNew,
+            logger: self.logger,
+            configuration: .init()
+        )
+        defer { XCTAssertNoThrow(try client.syncShutdownGracefully()) }
+        _ = try client.connect().wait()
+        try client.ping().wait()
+        try client.disconnect().wait()
+    }
+
     func testMQTTPublishQoS0() throws {
         let client = self.createClient(identifier: "testMQTTPublishQoS0")
         defer { XCTAssertNoThrow(try client.syncShutdownGracefully()) }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# run this with docker-compose -f docker/docker-compose.yml run test
+# run this with: docker-compose -f docker-compose.yml run test
 version: "3.3"
 
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     working_dir: /mqtt-nio
     volumes:
       - .:/mqtt-nio
+      - mosquitto-socket:/mqtt-nio/mosquitto/socket
     depends_on:
       - mosquitto
     environment:
@@ -19,8 +20,12 @@ services:
     volumes:
       - ./mosquitto/config:/mosquitto/config
       - ./mosquitto/certs:/mosquitto/certs
+      - mosquitto-socket:/mosquitto/socket
     ports:
       - "1883:1883"
       - "8883:8883"
       - "8080:8080"
       - "8081:8081"
+
+volumes:
+  mosquitto-socket:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     environment:
       - MOSQUITTO_SERVER=mosquitto
       - CI=true
-    command: /bin/bash -xcl "swift test --enable-test-discovery"
+    command: /bin/bash -xcl "swift test"
 
   mosquitto:
     image: eclipse-mosquitto

--- a/mosquitto/config/mosquitto.conf
+++ b/mosquitto/config/mosquitto.conf
@@ -36,3 +36,8 @@ allow_anonymous true
 cafile ./mosquitto/certs/ca.pem
 certfile ./mosquitto/certs/server.pem
 keyfile ./mosquitto/certs/server.key
+
+# Unix Domain Socket
+listener 0 ./mosquitto/socket/mosquitto.sock
+protocol mqtt
+allow_anonymous true

--- a/mosquitto/socket/.gitkeep
+++ b/mosquitto/socket/.gitkeep
@@ -1,0 +1,7 @@
+A local mosquitto server using `mosquitto/config/mosquitto.conf` will create a `mosquitto.sock` socket in this directory.
+
+If using the `docker-compose.yml` container environment, a shared container volume will be mounted here.
+
+This allows tests that connect to mosquitto via unix domain socket to assume the socket(s) will be found in this directory and work from multiple environments.
+
+Do not remove this directory.

--- a/scripts/mosquitto.sh
+++ b/scripts/mosquitto.sh
@@ -32,6 +32,7 @@ run-containerized-mosquitto()
         -p 8081:8081 \
         -v "$(pwd)"/mosquitto/config:/mosquitto/config \
         -v "$(pwd)"/mosquitto/certs:/mosquitto/certs \
+        -v "$(pwd)"/mosquitto/socket:/mosquitto/socket \
         eclipse-mosquitto
 }
 
@@ -49,13 +50,19 @@ fi
 cd "$(dirname "$(dirname "$0")")"
 
 if [[ $USE_CONTAINER -eq 1 ]]; then
+    if [ "$(uname)" != "Linux" ]; then
+        echo "warning: unix domain socket connections will not work with a mosquitto container on $(uname)"
+    fi
     run-containerized-mosquitto
 elif command -v mosquitto >/dev/null; then
     run-installed-mosquitto
+elif [ "$(uname)" = "Linux" ]; then
+    echo "notice: mosquitto not installed; running eclipse-mosquitto container instead..."
+    run-containerized-mosquitto
 else
+    echo "error: mosquitto must be installed"
     if [ "$(uname)" = "Darwin" ]; then
         echo "mosquitto can be installed on MacOS with: brew install mosquitto"
     fi
-    echo "notice: mosquitto not installed; running eclipse-mosquitto container instead..."
-    run-containerized-mosquitto
+    exit 1
 fi


### PR DESCRIPTION
The approach used for setting-up an `MQTTClient` to use a unix socket is similar to the approach used by mosquitto to configure listening on a unix socket; namely, setting the port to 0 indicates that the `host` string should be interpreted as a path to a socket.

From a semver perspective, this approach enables the unix domain sockets feature without breaking or otherwise changing an MQTTNIO interfaces. Prior to this change, specifying port 0 would have been an error, now it has meaning.

The docker-compose.yml files are updated to setup a shared "mosquitto-socket" volume. The mosquitto container will listen on a socket file in this volume. The "test"/"app" container also mounts this volume and thus can use the socket file found there to connect to mosquitto. The new unix socket configuration in the example mosquitto.conf is setup such that the socket path will work both with the docker-compose.yml setups as well as with a local (non-container) mosquitto instance.

The `mosquitto/socket` directory must be present in order to run a local mosquitto service with `mosquitto/conf/mosquitto.conf` since that configuration will listen on a socket in that directory. The `readme.md`
in that directory ensures its existence in git workspaces.