### PR TITLE
Make subscriptionIdentifier associated value a UInt32

### DIFF
--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
@@ -236,7 +236,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
     func subscribe(
         streamContinuation: MQTTSubscription.Continuation,
         packet: MQTTSubscribePacket,
-        promise: MQTTPromise<UInt>
+        promise: MQTTPromise<UInt32>
     ) {
         self.eventLoop.assertInEventLoop()
 
@@ -287,7 +287,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
     }
 
     func unsubscribe(
-        id: UInt,
+        id: UInt32,
         packetID: UInt16,
         properties: MQTTProperties,
         promise: MQTTPromise<Void>

--- a/Sources/MQTTNIO/MQTTProperties.swift
+++ b/Sources/MQTTNIO/MQTTProperties.swift
@@ -228,7 +228,7 @@ extension MQTTProperties.Property {
         case .contentType(let value): return .string(value)
         case .responseTopic(let value): return .string(value)
         case .correlationData(let value): return .binaryData(value)
-        case .subscriptionIdentifier(let value): return .variableLengthInteger(value)
+        case .subscriptionIdentifier(let value): return .variableLengthInteger(numericCast(value))
         case .sessionExpiryInterval(let value): return .fourByteInteger(value)
         case .assignedClientIdentifier(let value): return .string(value)
         case .serverKeepAlive(let value): return .twoByteInteger(value)
@@ -311,7 +311,7 @@ extension MQTTProperties.Property {
             return .correlationData(buffer)
         case .subscriptionIdentifier:
             let value = try MQTTSerializer.readVariableLengthInteger(from: &byteBuffer)
-            return .subscriptionIdentifier(UInt(value))
+            return .subscriptionIdentifier(UInt32(value))
         case .sessionExpiryInterval:
             guard let value: UInt32 = byteBuffer.readInteger() else { throw MQTTError.badResponse }
             return .sessionExpiryInterval(value)

--- a/Sources/MQTTNIO/MQTTProperties.swift
+++ b/Sources/MQTTNIO/MQTTProperties.swift
@@ -311,6 +311,7 @@ extension MQTTProperties.Property {
             return .correlationData(buffer)
         case .subscriptionIdentifier:
             let value = try MQTTSerializer.readVariableLengthInteger(from: &byteBuffer)
+            guard (1..<0xfffffff).contains(value) else { throw MQTTError.badResponse }
             return .subscriptionIdentifier(UInt32(value))
         case .sessionExpiryInterval:
             guard let value: UInt32 = byteBuffer.readInteger() else { throw MQTTError.badResponse }

--- a/Sources/MQTTNIO/MQTTProperties.swift
+++ b/Sources/MQTTNIO/MQTTProperties.swift
@@ -27,9 +27,10 @@ public struct MQTTProperties: Sendable {
         case responseTopic(String)
         /// Correlation data used to id a request/response in request/response interactions (available for PUBLISH)
         case correlationData(ByteBuffer)
-        /// Subscription identifier set in SUBSCRIBE packet and included in related PUBLISH packet
+        /// Subscription identifier set in SUBSCRIBE packet and included in related PUBLISH packet. Subscription
+        /// identifiers can have a value from 1 to 268435455(0xfffffff)
         /// (available for PUBLISH, SUBSCRIBE)
-        case subscriptionIdentifier(UInt)
+        case subscriptionIdentifier(UInt32)
         /// Interval before session expires (available for CONNECT, CONNACK, DISCONNECT)
         case sessionExpiryInterval(UInt32)
         /// Client identifier assigned to client if they didn't provide one (available for CONNACK)

--- a/Sources/MQTTNIO/Subscriptions/MQTTConnection+subscribe.swift
+++ b/Sources/MQTTNIO/Subscriptions/MQTTConnection+subscribe.swift
@@ -48,13 +48,13 @@ extension MQTTConnection {
     func subscribe(
         to subscriptions: [MQTTSubscribeInfoV5],
         properties: MQTTProperties = .init()
-    ) async throws -> (UInt, MQTTSubscription) {
+    ) async throws -> (UInt32, MQTTSubscription) {
         let (stream, streamContinuation) = MQTTSubscription.makeStream()
         if Task.isCancelled {
             throw MQTTError.cancelledTask
         }
         let packet = MQTTSubscribePacket(subscriptions: subscriptions, properties: properties, packetId: self.updatePacketId())
-        let subscriptionID: UInt = try await withCheckedThrowingContinuation { continuation in
+        let subscriptionID: UInt32 = try await withCheckedThrowingContinuation { continuation in
             self.channelHandler.subscribe(
                 streamContinuation: streamContinuation,
                 packet: packet,
@@ -64,7 +64,7 @@ extension MQTTConnection {
         return (subscriptionID, stream)
     }
 
-    func unsubscribe(id: UInt, properties: MQTTProperties = .init()) async throws {
+    func unsubscribe(id: UInt32, properties: MQTTProperties = .init()) async throws {
         try await withCheckedThrowingContinuation { continuation in
             self.channelHandler.unsubscribe(id: id, packetID: self.updatePacketId(), properties: properties, promise: .swift(continuation))
         }

--- a/Tests/MQTTNIOTests/MQTTSubscriptionsTests.swift
+++ b/Tests/MQTTNIOTests/MQTTSubscriptionsTests.swift
@@ -28,7 +28,7 @@ struct MQTTSubscriptionsTests {
         ]
         let (_, continuation) = MQTTSubscription.makeStream()
 
-        var subscriptionID: UInt = 0
+        var subscriptionID: UInt32 = 0
 
         switch try subscriptions.addSubscription(continuation: continuation, subscriptions: subscribeInfos, version: .v3_1_1) {
         case .subscribe(let subscriptionRef):
@@ -68,7 +68,7 @@ struct MQTTSubscriptionsTests {
         ]
         let (_, continuation) = MQTTSubscription.makeStream()
 
-        var subscriptionID: UInt = 0
+        var subscriptionID: UInt32 = 0
 
         switch try subscriptions.addSubscription(continuation: continuation, subscriptions: subscribeInfos, version: .v3_1_1) {
         case .subscribe(let subscriptionRef):


### PR DESCRIPTION
Previously it was a UInt and this caused a crash as it is serialised as an Int