### PR TITLE
Ensure we can run tests in parallel

### DIFF
--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -27,7 +27,7 @@ import NIOTransportServices
 import NIOSSL
 #endif
 
-@Suite("MQTTConnection Tests", .serialized)
+@Suite("MQTTConnection Tests")
 struct MQTTConnectionTests {
     static let hostname = ProcessInfo.processInfo.environment["MOSQUITTO_SERVER"] ?? "localhost"
 
@@ -458,7 +458,7 @@ struct MQTTConnectionTests {
             try await withThrowingTaskGroup { group in
                 group.addTask {
                     try await confirmation("multiLevelWildcard", expectedCount: 2) { receivedMessage in
-                        try await connection.subscribe(to: [.init(topicFilter: "home/kitchen/#", qos: .atLeastOnce)]) { subscription in
+                        try await connection.subscribe(to: [.init(topicFilter: "multiLevel/home/kitchen/#", qos: .atLeastOnce)]) { subscription in
                             var count = 0
                             for try await message in subscription {
                                 var buffer = message.payload
@@ -474,9 +474,13 @@ struct MQTTConnectionTests {
 
                 group.addTask {
                     try await Task.sleep(for: .seconds(1))
-                    try await connection.publish(to: "home/kitchen/temperature", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
-                    try await connection.publish(to: "home/livingroom/temperature", payload: ByteBuffer(string: "error"), qos: .atLeastOnce)
-                    try await connection.publish(to: "home/kitchen/humidity", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
+                    try await connection.publish(to: "multiLevel/home/kitchen/temperature", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
+                    try await connection.publish(
+                        to: "multiLevel/home/livingroom/temperature",
+                        payload: ByteBuffer(string: "error"),
+                        qos: .atLeastOnce
+                    )
+                    try await connection.publish(to: "multiLevel/home/kitchen/humidity", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
                 }
 
                 try await group.waitForAll()
@@ -494,7 +498,8 @@ struct MQTTConnectionTests {
             try await withThrowingTaskGroup { group in
                 group.addTask {
                     try await confirmation("singleLevelWildcard", expectedCount: 2) { receivedMessage in
-                        try await connection.subscribe(to: [.init(topicFilter: "home/+/temperature", qos: .atLeastOnce)]) { subscription in
+                        try await connection.subscribe(to: [.init(topicFilter: "singleLevel/home/+/temperature", qos: .atLeastOnce)]) {
+                            subscription in
                             var count = 0
                             for try await message in subscription {
                                 var buffer = message.payload
@@ -510,9 +515,13 @@ struct MQTTConnectionTests {
 
                 group.addTask {
                     try await Task.sleep(for: .seconds(1))
-                    try await connection.publish(to: "home/livingroom/temperature", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
-                    try await connection.publish(to: "home/garden/humidity", payload: ByteBuffer(string: "error"), qos: .atLeastOnce)
-                    try await connection.publish(to: "home/kitchen/temperature", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
+                    try await connection.publish(
+                        to: "singleLevel/home/livingroom/temperature",
+                        payload: ByteBuffer(string: "test"),
+                        qos: .atLeastOnce
+                    )
+                    try await connection.publish(to: "singleLevel/home/garden/humidity", payload: ByteBuffer(string: "error"), qos: .atLeastOnce)
+                    try await connection.publish(to: "singleLevel/home/kitchen/temperature", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
                 }
 
                 try await group.waitForAll()
@@ -533,8 +542,8 @@ struct MQTTConnectionTests {
                 group.addTask {
                     try await confirmation("overlappingSubscriptions", expectedCount: 2) { receivedMessage in
                         try await connection.subscribe(to: [
-                            .init(topicFilter: "home/+/temperature", qos: .atLeastOnce),
-                            .init(topicFilter: "home/kitchen/#", qos: .atLeastOnce),
+                            .init(topicFilter: "overlapping/home/+/temperature", qos: .atLeastOnce),
+                            .init(topicFilter: "overlapping/home/kitchen/#", qos: .atLeastOnce),
                         ]) { subscription in
                             var count = 0
                             for try await message in subscription {
@@ -551,7 +560,7 @@ struct MQTTConnectionTests {
 
                 group.addTask {
                     try await Task.sleep(for: .seconds(1))
-                    try await connection.publish(to: "home/kitchen/temperature", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
+                    try await connection.publish(to: "overlapping/home/kitchen/temperature", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
                 }
 
                 try await group.waitForAll()

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -97,65 +97,147 @@ struct MQTTConnectionTests {
         }
     }
 
-    @Test("Connect with TLS")
-    func tlsConnect() async throws {
-        try await MQTTConnection.withConnection(
-            address: .hostname(Self.hostname, port: 8883),
-            configuration: .init(
-                useSSL: true,
-                tlsConfiguration: self.getTLSConfiguration(),
-                sniServerName: "soto.codes"
-            ),
-            identifier: "tlsConnect",
-            eventLoop: Self.eventLoopGroupSingleton.any(),
-            logger: self.logger
-        ) { connection in
-            try await connection.ping()
-        }
-    }
+    @Suite(.serialized)
+    struct TLS {
+        static let hostname = ProcessInfo.processInfo.environment["MOSQUITTO_SERVER"] ?? "localhost"
 
-    @Test("Connect with WebSocket and TLS")
-    func webSocketAndTLSConnect() async throws {
-        try await MQTTConnection.withConnection(
-            address: .hostname(Self.hostname, port: 8081),
-            configuration: .init(
-                timeout: .seconds(5),
-                useSSL: true,
-                tlsConfiguration: self.getTLSConfiguration(),
-                sniServerName: "soto.codes",
-                webSocketConfiguration: .init()
-            ),
-            identifier: "webSocketAndTLSConnect",
-            eventLoop: Self.eventLoopGroupSingleton.any(),
-            logger: self.logger
-        ) { connection in
-            try await connection.ping()
-        }
-    }
+        static let rootPath = #filePath
+            .split(separator: "/", omittingEmptySubsequences: false)
+            .dropLast(3)
+            .joined(separator: "/")
 
-    #if canImport(Network)
-    @Test("Connect with TLS from P12")
-    func tlsConnectFromP12() async throws {
-        try await MQTTConnection.withConnection(
-            address: .hostname(Self.hostname, port: 8883),
-            configuration: .init(
-                useSSL: true,
-                tlsConfiguration: .ts(
-                    .init(
-                        trustRoots: .der(Self.rootPath + "/mosquitto/certs/ca.der"),
-                        clientIdentity: .p12(filename: Self.rootPath + "/mosquitto/certs/client.p12", password: "MQTTNIOClientCertPassword")
-                    )
+        static var eventLoopGroupSingleton: EventLoopGroup {
+            #if os(Linux)
+            MultiThreadedEventLoopGroup.singleton
+            #else
+            // Return TS Eventloop for non-Linux builds, as we use TS TLS
+            NIOTSEventLoopGroup.singleton
+            #endif
+        }
+
+        let logger: Logger = {
+            var logger = Logger(label: "MQTTNIOTests")
+            logger.logLevel = .trace
+            return logger
+        }()
+
+        @Test("Connect with TLS")
+        func tlsConnect() async throws {
+            try await MQTTConnection.withConnection(
+                address: .hostname(Self.hostname, port: 8883),
+                configuration: .init(
+                    useSSL: true,
+                    tlsConfiguration: self.getTLSConfiguration(),
+                    sniServerName: "soto.codes"
                 ),
-                sniServerName: "soto.codes"
-            ),
-            identifier: "tlsConnectFromP12",
-            eventLoop: Self.eventLoopGroupSingleton.any(),
-            logger: self.logger
-        ) { connection in
-            try await connection.ping()
+                identifier: "tlsConnect",
+                eventLoop: Self.eventLoopGroupSingleton.any(),
+                logger: self.logger
+            ) { connection in
+                try await connection.ping()
+            }
+        }
+
+        @Test("Connect with WebSocket and TLS")
+        func webSocketAndTLSConnect() async throws {
+            try await MQTTConnection.withConnection(
+                address: .hostname(Self.hostname, port: 8081),
+                configuration: .init(
+                    timeout: .seconds(5),
+                    useSSL: true,
+                    tlsConfiguration: self.getTLSConfiguration(),
+                    sniServerName: "soto.codes",
+                    webSocketConfiguration: .init()
+                ),
+                identifier: "webSocketAndTLSConnect",
+                eventLoop: Self.eventLoopGroupSingleton.any(),
+                logger: self.logger
+            ) { connection in
+                try await connection.ping()
+            }
+        }
+
+        #if canImport(Network)
+        @Test("Connect with TLS from P12")
+        func tlsConnectFromP12() async throws {
+            try await MQTTConnection.withConnection(
+                address: .hostname(Self.hostname, port: 8883),
+                configuration: .init(
+                    useSSL: true,
+                    tlsConfiguration: .ts(
+                        .init(
+                            trustRoots: .der(Self.rootPath + "/mosquitto/certs/ca.der"),
+                            clientIdentity: .p12(filename: Self.rootPath + "/mosquitto/certs/client.p12", password: "MQTTNIOClientCertPassword")
+                        )
+                    ),
+                    sniServerName: "soto.codes"
+                ),
+                identifier: "tlsConnectFromP12",
+                eventLoop: Self.eventLoopGroupSingleton.any(),
+                logger: self.logger
+            ) { connection in
+                try await connection.ping()
+            }
+        }
+        #endif
+
+        var _tlsConfiguration: MQTTConnectionConfiguration.TLSConfigurationType {
+            get throws {
+                #if os(Linux)
+                let rootCertificate = try NIOSSLCertificate.fromPEMFile(Self.rootPath + "/mosquitto/certs/ca.pem")
+                let certificate = try NIOSSLCertificate.fromPEMFile(Self.rootPath + "/mosquitto/certs/client.pem")
+                let privateKey = try NIOSSLPrivateKey(file: Self.rootPath + "/mosquitto/certs/client.key", format: .pem)
+                var tlsConfiguration = TLSConfiguration.makeClientConfiguration()
+                tlsConfiguration.trustRoots = .certificates(rootCertificate)
+                tlsConfiguration.certificateChain = certificate.map { .certificate($0) }
+                tlsConfiguration.privateKey = .privateKey(privateKey)
+                return .niossl(tlsConfiguration)
+                #else
+                let caData = try Data(contentsOf: URL(fileURLWithPath: Self.rootPath + "/mosquitto/certs/ca.der"))
+                let trustRootCertificates = SecCertificateCreateWithData(nil, caData as CFData).map { [$0] }
+                let p12Data = try Data(contentsOf: URL(fileURLWithPath: Self.rootPath + "/mosquitto/certs/client.p12"))
+                let options: [String: String] = [kSecImportExportPassphrase as String: "MQTTNIOClientCertPassword"]
+                var rawItems: CFArray?
+                guard SecPKCS12Import(p12Data as CFData, options as CFDictionary, &rawItems) == errSecSuccess else {
+                    throw MQTTError.wrongTLSConfig
+                }
+                let items = rawItems! as! [[String: Any]]
+                let firstItem = items[0]
+                let identity = firstItem[kSecImportItemIdentity as String] as! SecIdentity?
+                let tlsConfiguration = TSTLSConfiguration(
+                    trustRoots: trustRootCertificates,
+                    clientIdentity: identity
+                )
+                return .ts(tlsConfiguration)
+                #endif
+            }
+        }
+
+        func getTLSConfiguration(
+            withTrustRoots: Bool = true,
+            withClientKey: Bool = true
+        ) throws -> MQTTConnectionConfiguration.TLSConfigurationType {
+            switch try self._tlsConfiguration {
+            #if os(macOS) || os(Linux)
+            case .niossl(let config):
+                var tlsConfig = TLSConfiguration.makeClientConfiguration()
+                tlsConfig.trustRoots = withTrustRoots ? (config.trustRoots ?? .default) : .default
+                tlsConfig.certificateChain = withClientKey ? config.certificateChain : []
+                tlsConfig.privateKey = withClientKey ? config.privateKey : nil
+                return .niossl(tlsConfig)
+            #endif
+            #if canImport(Network)
+            case .ts(let config):
+                return .ts(
+                    TSTLSConfiguration(
+                        trustRoots: withTrustRoots ? config.trustRoots : nil,
+                        clientIdentity: withClientKey ? config.clientIdentity : nil
+                    )
+                )
+            #endif
+            }
         }
     }
-    #endif
 
     @Test("Connect with Unix Domain Socket")
     func unixDomainSocketConnect() async throws {
@@ -586,63 +668,6 @@ struct MQTTConnectionTests {
         // Return TS Eventloop for non-Linux builds, as we use TS TLS
         NIOTSEventLoopGroup.singleton
         #endif
-    }
-
-    var _tlsConfiguration: MQTTConnectionConfiguration.TLSConfigurationType {
-        get throws {
-            #if os(Linux)
-            let rootCertificate = try NIOSSLCertificate.fromPEMFile(Self.rootPath + "/mosquitto/certs/ca.pem")
-            let certificate = try NIOSSLCertificate.fromPEMFile(Self.rootPath + "/mosquitto/certs/client.pem")
-            let privateKey = try NIOSSLPrivateKey(file: Self.rootPath + "/mosquitto/certs/client.key", format: .pem)
-            var tlsConfiguration = TLSConfiguration.makeClientConfiguration()
-            tlsConfiguration.trustRoots = .certificates(rootCertificate)
-            tlsConfiguration.certificateChain = certificate.map { .certificate($0) }
-            tlsConfiguration.privateKey = .privateKey(privateKey)
-            return .niossl(tlsConfiguration)
-            #else
-            let caData = try Data(contentsOf: URL(fileURLWithPath: Self.rootPath + "/mosquitto/certs/ca.der"))
-            let trustRootCertificates = SecCertificateCreateWithData(nil, caData as CFData).map { [$0] }
-            let p12Data = try Data(contentsOf: URL(fileURLWithPath: Self.rootPath + "/mosquitto/certs/client.p12"))
-            let options: [String: String] = [kSecImportExportPassphrase as String: "MQTTNIOClientCertPassword"]
-            var rawItems: CFArray?
-            guard SecPKCS12Import(p12Data as CFData, options as CFDictionary, &rawItems) == errSecSuccess else {
-                throw MQTTError.wrongTLSConfig
-            }
-            let items = rawItems! as! [[String: Any]]
-            let firstItem = items[0]
-            let identity = firstItem[kSecImportItemIdentity as String] as! SecIdentity?
-            let tlsConfiguration = TSTLSConfiguration(
-                trustRoots: trustRootCertificates,
-                clientIdentity: identity
-            )
-            return .ts(tlsConfiguration)
-            #endif
-        }
-    }
-
-    func getTLSConfiguration(
-        withTrustRoots: Bool = true,
-        withClientKey: Bool = true
-    ) throws -> MQTTConnectionConfiguration.TLSConfigurationType {
-        switch try self._tlsConfiguration {
-        #if os(macOS) || os(Linux)
-        case .niossl(let config):
-            var tlsConfig = TLSConfiguration.makeClientConfiguration()
-            tlsConfig.trustRoots = withTrustRoots ? (config.trustRoots ?? .default) : .default
-            tlsConfig.certificateChain = withClientKey ? config.certificateChain : []
-            tlsConfig.privateKey = withClientKey ? config.privateKey : nil
-            return .niossl(tlsConfig)
-        #endif
-        #if canImport(Network)
-        case .ts(let config):
-            return .ts(
-                TSTLSConfiguration(
-                    trustRoots: withTrustRoots ? config.trustRoots : nil,
-                    clientIdentity: withClientKey ? config.clientIdentity : nil
-                )
-            )
-        #endif
-        }
     }
 }
 

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -103,7 +103,7 @@ struct MQTTConnectionTests {
             address: .hostname(Self.hostname, port: 8883),
             configuration: .init(
                 useSSL: true,
-                tlsConfiguration: Self.getTLSConfiguration(),
+                tlsConfiguration: self.getTLSConfiguration(),
                 sniServerName: "soto.codes"
             ),
             identifier: "tlsConnect",
@@ -121,7 +121,7 @@ struct MQTTConnectionTests {
             configuration: .init(
                 timeout: .seconds(5),
                 useSSL: true,
-                tlsConfiguration: Self.getTLSConfiguration(),
+                tlsConfiguration: self.getTLSConfiguration(),
                 sniServerName: "soto.codes",
                 webSocketConfiguration: .init()
             ),
@@ -588,7 +588,7 @@ struct MQTTConnectionTests {
         #endif
     }
 
-    static var _tlsConfiguration: MQTTConnectionConfiguration.TLSConfigurationType {
+    var _tlsConfiguration: MQTTConnectionConfiguration.TLSConfigurationType {
         get throws {
             #if os(Linux)
             let rootCertificate = try NIOSSLCertificate.fromPEMFile(Self.rootPath + "/mosquitto/certs/ca.pem")
@@ -620,11 +620,11 @@ struct MQTTConnectionTests {
         }
     }
 
-    static func getTLSConfiguration(
+    func getTLSConfiguration(
         withTrustRoots: Bool = true,
         withClientKey: Bool = true
     ) throws -> MQTTConnectionConfiguration.TLSConfigurationType {
-        switch try Self._tlsConfiguration {
+        switch try self._tlsConfiguration {
         #if os(macOS) || os(Linux)
         case .niossl(let config):
             var tlsConfig = TLSConfiguration.makeClientConfiguration()

--- a/Tests/MQTTNIOTests/MQTTConnectionV5Tests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionV5Tests.swift
@@ -27,7 +27,7 @@ import NIOTransportServices
 import NIOSSL
 #endif
 
-@Suite("MQTTConnection v5 Tests", .serialized)
+@Suite("MQTTConnection v5 Tests")
 struct MQTTConnectionV5Tests {
     static let hostname = ProcessInfo.processInfo.environment["MOSQUITTO_SERVER"] ?? "localhost"
 
@@ -123,7 +123,7 @@ struct MQTTConnectionV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "subscribeFlags",
+            identifier: "subscribeFlagsV5",
             logger: self.logger
         ) { connection in
             try await withThrowingTaskGroup { group in
@@ -172,7 +172,7 @@ struct MQTTConnectionV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "contentType",
+            identifier: "contentTypeV5",
             logger: self.logger
         ) { connection in
             try await withThrowingTaskGroup { group in
@@ -212,7 +212,7 @@ struct MQTTConnectionV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "userProperty",
+            identifier: "userPropertyV5",
             logger: self.logger
         ) { connection in
             try await withThrowingTaskGroup { group in
@@ -261,7 +261,7 @@ struct MQTTConnectionV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "invalidTopicName",
+            identifier: "invalidTopicNameV5",
             logger: self.logger
         ) { connection in
             _ = await #expect(throws: MQTTPacketError.invalidTopicName) {
@@ -280,7 +280,7 @@ struct MQTTConnectionV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "badPublish",
+            identifier: "badPublishV5",
             logger: self.logger
         ) { connection in
             let error = await #expect(throws: MQTTError.self) {
@@ -306,7 +306,7 @@ struct MQTTConnectionV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "outOfRangeTopicAlias",
+            identifier: "outOfRangeTopicAliasV5",
             logger: self.logger
         ) { connection in
             _ = await #expect(throws: MQTTPacketError.topicAliasOutOfRange) {
@@ -325,7 +325,7 @@ struct MQTTConnectionV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "publishWithSubscriptionID",
+            identifier: "publishWithSubscriptionIDV5",
             logger: self.logger
         ) { connection in
             _ = await #expect(throws: MQTTPacketError.publishIncludesSubscription) {
@@ -381,13 +381,14 @@ struct MQTTConnectionV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "multiLevelWildcard",
+            identifier: "multiLevelWildcardV5",
             logger: self.logger
         ) { connection in
             try await withThrowingTaskGroup { group in
                 group.addTask {
                     try await confirmation("multiLevelWildcard", expectedCount: 2) { receivedMessage in
-                        try await connection.v5.subscribe(to: [.init(topicFilter: "home/kitchen/#", qos: .atLeastOnce)]) { subscription in
+                        try await connection.v5.subscribe(to: [.init(topicFilter: "multiLevelV5/home/kitchen/#", qos: .atLeastOnce)]) {
+                            subscription in
                             var count = 0
                             for try await message in subscription {
                                 var buffer = message.payload
@@ -404,9 +405,21 @@ struct MQTTConnectionV5Tests {
 
                 group.addTask {
                     try await Task.sleep(for: .seconds(1))
-                    _ = try await connection.v5.publish(to: "home/kitchen/temperature", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
-                    _ = try await connection.v5.publish(to: "home/livingroom/temperature", payload: ByteBuffer(string: "error"), qos: .atLeastOnce)
-                    _ = try await connection.v5.publish(to: "home/kitchen/humidity", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
+                    _ = try await connection.v5.publish(
+                        to: "multiLevelV5/home/kitchen/temperature",
+                        payload: ByteBuffer(string: "test"),
+                        qos: .atLeastOnce
+                    )
+                    _ = try await connection.v5.publish(
+                        to: "multiLevelV5/home/livingroom/temperature",
+                        payload: ByteBuffer(string: "error"),
+                        qos: .atLeastOnce
+                    )
+                    _ = try await connection.v5.publish(
+                        to: "multiLevelV5/home/kitchen/humidity",
+                        payload: ByteBuffer(string: "test"),
+                        qos: .atLeastOnce
+                    )
                 }
 
                 try await group.waitForAll()
@@ -419,13 +432,14 @@ struct MQTTConnectionV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "singleLevelWildcard",
+            identifier: "singleLevelWildcardV5",
             logger: self.logger
         ) { connection in
             try await withThrowingTaskGroup { group in
                 group.addTask {
                     try await confirmation("singleLevelWildcard", expectedCount: 2) { receivedMessage in
-                        try await connection.v5.subscribe(to: [.init(topicFilter: "home/+/temperature", qos: .atLeastOnce)]) { subscription in
+                        try await connection.v5.subscribe(to: [.init(topicFilter: "singleLevelV5/home/+/temperature", qos: .atLeastOnce)]) {
+                            subscription in
                             var count = 0
                             for try await message in subscription {
                                 var buffer = message.payload
@@ -442,9 +456,21 @@ struct MQTTConnectionV5Tests {
 
                 group.addTask {
                     try await Task.sleep(for: .seconds(1))
-                    _ = try await connection.v5.publish(to: "home/livingroom/temperature", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
-                    _ = try await connection.v5.publish(to: "home/garden/humidity", payload: ByteBuffer(string: "error"), qos: .atLeastOnce)
-                    _ = try await connection.v5.publish(to: "home/kitchen/temperature", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
+                    _ = try await connection.v5.publish(
+                        to: "singleLevelV5/home/livingroom/temperature",
+                        payload: ByteBuffer(string: "test"),
+                        qos: .atLeastOnce
+                    )
+                    _ = try await connection.v5.publish(
+                        to: "singleLevelV5/home/garden/humidity",
+                        payload: ByteBuffer(string: "error"),
+                        qos: .atLeastOnce
+                    )
+                    _ = try await connection.v5.publish(
+                        to: "singleLevelV5/home/kitchen/temperature",
+                        payload: ByteBuffer(string: "test"),
+                        qos: .atLeastOnce
+                    )
                 }
 
                 try await group.waitForAll()
@@ -459,15 +485,15 @@ struct MQTTConnectionV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "overlappingSubscriptions",
+            identifier: "overlappingSubscriptionsV5",
             logger: self.logger
         ) { connection in
             try await withThrowingTaskGroup { group in
                 group.addTask {
                     try await confirmation("overlappingSubscriptions", expectedCount: 2) { receivedMessage in
                         try await connection.v5.subscribe(to: [
-                            .init(topicFilter: "home/+/temperature", qos: .atLeastOnce),
-                            .init(topicFilter: "home/kitchen/#", qos: .atLeastOnce),
+                            .init(topicFilter: "overlappingV5/home/+/temperature", qos: .atLeastOnce),
+                            .init(topicFilter: "overlappingV5/home/kitchen/#", qos: .atLeastOnce),
                         ]) { subscription in
                             var count = 0
                             for try await message in subscription {
@@ -485,7 +511,11 @@ struct MQTTConnectionV5Tests {
 
                 group.addTask {
                     try await Task.sleep(for: .seconds(1))
-                    _ = try await connection.v5.publish(to: "home/kitchen/temperature", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
+                    _ = try await connection.v5.publish(
+                        to: "overlappingV5/home/kitchen/temperature",
+                        payload: ByteBuffer(string: "test"),
+                        qos: .atLeastOnce
+                    )
                 }
 
                 try await group.waitForAll()


### PR DESCRIPTION
Every test needs a unique client identifier and they shouldn't use the same subscription id

result: faster tests