### PR TITLE
Cleanup MQTTError

### DIFF
--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler+stateMachine.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler+stateMachine.swift
@@ -81,7 +81,7 @@ extension MQTTChannelHandler {
                 return .sendPacket(state.context)
             case .closed:
                 self = .closed
-                return .throwError(MQTTError.noConnection)
+                return .throwError(MQTTError.connectionClosed)
             }
         }
 

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
@@ -68,7 +68,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
     func waitOnInitialized() -> EventLoopFuture<Void> {
         switch self.stateMachine.waitOnInitialized() {
         case .reportedClosed(let error):
-            return self.eventLoop.makeFailedFuture(error ?? MQTTError.noConnection)
+            return self.eventLoop.makeFailedFuture(error ?? MQTTError.connectionClosed)
         case .done:
             return self.eventLoop.makeSucceededVoidFuture()
         }

--- a/Sources/MQTTNIO/MQTTError.swift
+++ b/Sources/MQTTNIO/MQTTError.swift
@@ -31,18 +31,14 @@ public enum MQTTError: Error, Sendable {
         case unrecognizedReturnValue = 0xFF
     }
 
-    /// You called connect on a client that is already connected to the broker
-    case alreadyConnected
-    /// Client has already been shutdown
-    case alreadyShutdown
     /// We received an unexpected message while connecting
     case failedToConnect
     /// We received an unsuccessful connection return value
     case connectionError(ConnectionReturnValue)
     /// We received an unsuccessful return value from either a connect or publish
     case reasonError(MQTTReasonCode)
-    /// client in not connected
-    case noConnection
+    /// client is closed
+    case connectionClosed
     /// the server disconnected
     case serverDisconnection(MQTTAckV5)
     /// the server closed the connection. If this happens during a publish you can resend

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -640,10 +640,8 @@ struct MQTTConnectionTests {
 extension MQTTError: Equatable {
     public static func == (lhs: MQTTError, rhs: MQTTError) -> Bool {
         switch (lhs, rhs) {
-        case (.alreadyConnected, .alreadyConnected),
-            (.alreadyShutdown, .alreadyShutdown),
-            (.failedToConnect, .failedToConnect),
-            (.noConnection, .noConnection),
+        case (.failedToConnect, .failedToConnect),
+            (.connectionClosed, .connectionClosed),
             (.serverClosedConnection, .serverClosedConnection),
             (.unexpectedMessage, .unexpectedMessage),
             (.decodeError, .decodeError),


### PR DESCRIPTION
Removed some unused errors, renamed `noConnection` to `connectionClosed`
I did have a look to see if I could change this to a `struct` but the different associated values make that very difficult. I think it probably best to wait for extensible enums