### PR TITLE
Adopt Swift 6 language mode and "NonisolatedNonsendingByDefault"

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   app:
-    image: swift:6.1
+    image: swift:6.2
     volumes:
       - ..:/workspace
       - mosquitto-socket:/workspace/mosquitto/socket

--- a/.github/workflows/api-breakage.yml
+++ b/.github/workflows/api-breakage.yml
@@ -7,7 +7,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     container:
-      image: swift:6.2
+      image: swift:latest
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/api-breakage.yml
+++ b/.github/workflows/api-breakage.yml
@@ -7,7 +7,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     container:
-      image: swift:6.1
+      image: swift:6.2
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       uses: actions/checkout@v6
     - name: Xcodebuild
       run: |
-        xcodebuild build -scheme mqtt-nio -destination 'platform=iOS Simulator,name=iPhone 16'
+        xcodebuild build -scheme mqtt-nio -destination 'platform=iOS Simulator,name=iPhone 17'
 
   linux-unit:
     runs-on: ubuntu-latest
@@ -59,7 +59,6 @@ jobs:
     strategy:
       matrix:
         tag:
-          - swift:6.1
           - swift:6.2
     container:
       image: ${{ matrix.tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
+    - name: Select appropriate Xcode version
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
     - name: Checkout
       uses: actions/checkout@v6
     - name: Xcodebuild

--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,7 @@ import PackageDescription
 
 var defaultSwiftSettings: [SwiftSetting] =
     [
-        .swiftLanguageMode(.v6),
-        .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+        .enableUpcomingFeature("NonisolatedNonsendingByDefault")
     ]
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,12 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.2
 
 import PackageDescription
+
+var defaultSwiftSettings: [SwiftSetting] =
+    [
+        .swiftLanguageMode(.v6),
+        .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+    ]
 
 let package = Package(
     name: "mqtt-nio",
@@ -24,9 +30,15 @@ let package = Package(
                 .product(name: "NIOWebSocket", package: "swift-nio"),
                 .product(name: "NIOSSL", package: "swift-nio-ssl", condition: .when(platforms: [.linux, .macOS])),
                 .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
-            ]
+            ],
+            swiftSettings: defaultSwiftSettings
         ),
-        .testTarget(name: "MQTTNIOTests", dependencies: ["MQTTNIO"]),
-    ],
-    swiftLanguageModes: [.v5]
+        .testTarget(
+            name: "MQTTNIOTests",
+            dependencies: [
+                .target(name: "MQTTNIO")
+            ],
+            swiftSettings: defaultSwiftSettings
+        ),
+    ]
 )

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MQTT NIO
 
 [![sswg:sandbox|94x20](https://img.shields.io/badge/sswg-sandbox-lightgrey.svg)](https://github.com/swift-server/sswg/blob/master/process/incubation.md#sandbox-level)
-[<img src="https://img.shields.io/badge/swift-6.1-brightgreen.svg" alt="Swift 6.1" />](https://swift.org)
+[<img src="https://img.shields.io/badge/swift-6.2-brightgreen.svg" alt="Swift 6.2" />](https://swift.org)
 [<img src="https://github.com/swift-server-community/mqtt-nio/workflows/CI/badge.svg" />](https://github.com/swift-server-community/mqtt-nio/workflows/CI/badge.svg)
 ![Codecov](https://img.shields.io/codecov/c/github/swift-server-community/mqtt-nio)
 

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
@@ -413,6 +413,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                 // otherwise reschedule task
                 if channelHandler.lastPingreqEventTime + channelHandler.pingreqTimeout <= .now() {
                     guard context.channel.isActive else { return }
+                    let loopBoundContext = NIOLoopBound(context, eventLoop: eventLoop)
                     channelHandler.sendMessage(MQTTPingreqPacket()) { message in
                         guard message.type == .PINGRESP else { return false }
                         return true
@@ -420,13 +421,13 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                     .whenComplete { result in
                         switch result {
                         case .failure(let error):
-                            channelHandler.failTasksAndCloseSubscriptions(with: error)
-                            context.fireErrorCaught(error)
+                            self.channelHandler.value.failTasksAndCloseSubscriptions(with: error)
+                            loopBoundContext.value.fireErrorCaught(error)
                         case .success:
                             break
                         }
-                        channelHandler.lastPingreqEventTime = .now()
-                        channelHandler.schedulePingreqCallback()
+                        self.channelHandler.value.lastPingreqEventTime = .now()
+                        self.channelHandler.value.schedulePingreqCallback()
                     }
                 } else {
                     channelHandler.schedulePingreqCallback()

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
@@ -195,12 +195,13 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
         case .exactlyOnce:
             let loopBoundChannelHandler = NIOLoopBound(channelHandler, eventLoop: self.eventLoop)
             let loopBoundContext = NIOLoopBound(context, eventLoop: self.eventLoop)
-            var publish = message.publish
+            // TODO: Investigate what to do if we receive a publish message while waiting for a PUBREL
+            //var publish = message.publish
             self.sendMessage(MQTTPubAckPacket(type: .PUBREC, packetId: message.packetId)) { newMessage in
                 guard newMessage.packetId == message.packetId else { return false }
                 // if we receive a publish message while waiting for a PUBREL from broker then replace data to be published and retry PUBREC
-                if newMessage.type == .PUBLISH, let publishMessage = newMessage as? MQTTPublishPacket {
-                    publish = publishMessage.publish
+                if newMessage.type == .PUBLISH {
+                    //publish = publishMessage.publish
                     throw MQTTError.retrySend
                 }
                 // if we receive anything but a PUBREL then throw unexpected message
@@ -208,7 +209,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                 // now we have received the PUBREL we can process the published message. PUBCOMP is sent by `respondToPubrel`
                 return true
             }
-            .map { _ in publish }
+            //.map { _ in publish }
             .whenComplete { result in
                 switch result {
                 case .failure(let error):
@@ -222,8 +223,8 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                         loopBoundContext.value.close(promise: nil)
                         loopBoundChannelHandler.value.logger.error("Error during QoS 2 publish flow", metadata: ["mqtt_error": .string("\(error)")])
                     }
-                case .success(let publish):
-                    loopBoundChannelHandler.value.subscriptions.notify(publish)
+                case .success:
+                    loopBoundChannelHandler.value.subscriptions.notify(message.publish)
                 }
             }
         }

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
@@ -133,7 +133,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                             "mqtt_topicName": .string(publishMessage.publish.topicName),
                         ]
                     )
-                    self.respondToPublish(publishMessage, channelHandler: self, context: context)
+                    self.respondToPublish(publishMessage, context: context)
                     return
                 case .succeedTask(let task):
                     if message.type == .PUBREL {
@@ -170,7 +170,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
     /// If QoS is `.atMostOnce` then no response is required
     /// If QoS is `.atLeastOnce` then send PUBACK
     /// If QoS is `.exactlyOnce` then send PUBREC, wait for PUBREL and then respond with PUBCOMP (in `respondToPubrel`)
-    private func respondToPublish(_ message: MQTTPublishPacket, channelHandler: MQTTChannelHandler, context: ChannelHandlerContext) {
+    private func respondToPublish(_ message: MQTTPublishPacket, context: ChannelHandlerContext) {
         switch message.publish.qos {
         case .atMostOnce:
             self.subscriptions.notify(message.publish)

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
@@ -133,7 +133,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                             "mqtt_topicName": .string(publishMessage.publish.topicName),
                         ]
                     )
-                    self.respondToPublish(publishMessage, context: context)
+                    self.respondToPublish(publishMessage, channelHandler: self, context: context)
                     return
                 case .succeedTask(let task):
                     if message.type == .PUBREL {
@@ -170,27 +170,31 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
     /// If QoS is `.atMostOnce` then no response is required
     /// If QoS is `.atLeastOnce` then send PUBACK
     /// If QoS is `.exactlyOnce` then send PUBREC, wait for PUBREL and then respond with PUBCOMP (in `respondToPubrel`)
-    private func respondToPublish(_ message: MQTTPublishPacket, context: ChannelHandlerContext) {
+    private func respondToPublish(_ message: MQTTPublishPacket, channelHandler: MQTTChannelHandler, context: ChannelHandlerContext) {
         switch message.publish.qos {
         case .atMostOnce:
             self.subscriptions.notify(message.publish)
 
         case .atLeastOnce:
+            let loopBoundChannelHandler = NIOLoopBound(channelHandler, eventLoop: self.eventLoop)
+            let loopBoundContext = NIOLoopBound(context, eventLoop: self.eventLoop)
             context.channel.writeAndFlush(MQTTPubAckPacket(type: .PUBACK, packetId: message.packetId))
                 .map { _ in message.publish }
                 .whenComplete { result in
                     switch result {
                     case .success(let publish):
-                        self.subscriptions.notify(publish)
+                        loopBoundChannelHandler.value.subscriptions.notify(publish)
                     case .failure(let error):
-                        self.failTasksAndCloseSubscriptions(with: error)
-                        context.fireErrorCaught(error)
-                        context.close(promise: nil)
-                        self.logger.error("Error sending PUBACK", metadata: ["mqtt_error": .string("\(error)")])
+                        loopBoundChannelHandler.value.failTasksAndCloseSubscriptions(with: error)
+                        loopBoundContext.value.fireErrorCaught(error)
+                        loopBoundContext.value.close(promise: nil)
+                        loopBoundChannelHandler.value.logger.error("Error sending PUBACK", metadata: ["mqtt_error": .string("\(error)")])
                     }
                 }
 
         case .exactlyOnce:
+            let loopBoundChannelHandler = NIOLoopBound(channelHandler, eventLoop: self.eventLoop)
+            let loopBoundContext = NIOLoopBound(context, eventLoop: self.eventLoop)
             var publish = message.publish
             self.sendMessage(MQTTPubAckPacket(type: .PUBREC, packetId: message.packetId)) { newMessage in
                 guard newMessage.packetId == message.packetId else { return false }
@@ -213,13 +217,13 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                         // do not report retrySend error
                         return
                     default:
-                        self.failTasksAndCloseSubscriptions(with: error)
-                        context.fireErrorCaught(error)
-                        context.close(promise: nil)
-                        self.logger.error("Error during QoS 2 publish flow", metadata: ["mqtt_error": .string("\(error)")])
+                        loopBoundChannelHandler.value.failTasksAndCloseSubscriptions(with: error)
+                        loopBoundContext.value.fireErrorCaught(error)
+                        loopBoundContext.value.close(promise: nil)
+                        loopBoundChannelHandler.value.logger.error("Error during QoS 2 publish flow", metadata: ["mqtt_error": .string("\(error)")])
                     }
                 case .success(let publish):
-                    self.subscriptions.notify(publish)
+                    loopBoundChannelHandler.value.subscriptions.notify(publish)
                 }
             }
         }

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
@@ -176,25 +176,22 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
             self.subscriptions.notify(message.publish)
 
         case .atLeastOnce:
-            let loopBoundChannelHandler = NIOLoopBound(channelHandler, eventLoop: self.eventLoop)
-            let loopBoundContext = NIOLoopBound(context, eventLoop: self.eventLoop)
             context.channel.writeAndFlush(MQTTPubAckPacket(type: .PUBACK, packetId: message.packetId))
+                .assumeIsolated()
                 .map { _ in message.publish }
                 .whenComplete { result in
                     switch result {
                     case .success(let publish):
-                        loopBoundChannelHandler.value.subscriptions.notify(publish)
+                        self.subscriptions.notify(publish)
                     case .failure(let error):
-                        loopBoundChannelHandler.value.failTasksAndCloseSubscriptions(with: error)
-                        loopBoundContext.value.fireErrorCaught(error)
-                        loopBoundContext.value.close(promise: nil)
-                        loopBoundChannelHandler.value.logger.error("Error sending PUBACK", metadata: ["mqtt_error": .string("\(error)")])
+                        self.failTasksAndCloseSubscriptions(with: error)
+                        context.fireErrorCaught(error)
+                        context.close(promise: nil)
+                        self.logger.error("Error sending PUBACK", metadata: ["mqtt_error": .string("\(error)")])
                     }
                 }
 
         case .exactlyOnce:
-            let loopBoundChannelHandler = NIOLoopBound(channelHandler, eventLoop: self.eventLoop)
-            let loopBoundContext = NIOLoopBound(context, eventLoop: self.eventLoop)
             // TODO: Investigate what to do if we receive a publish message while waiting for a PUBREL
             //var publish = message.publish
             self.sendMessage(MQTTPubAckPacket(type: .PUBREC, packetId: message.packetId)) { newMessage in
@@ -209,6 +206,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                 // now we have received the PUBREL we can process the published message. PUBCOMP is sent by `respondToPubrel`
                 return true
             }
+            .assumeIsolated()
             //.map { _ in publish }
             .whenComplete { result in
                 switch result {
@@ -218,13 +216,13 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                         // do not report retrySend error
                         return
                     default:
-                        loopBoundChannelHandler.value.failTasksAndCloseSubscriptions(with: error)
-                        loopBoundContext.value.fireErrorCaught(error)
-                        loopBoundContext.value.close(promise: nil)
-                        loopBoundChannelHandler.value.logger.error("Error during QoS 2 publish flow", metadata: ["mqtt_error": .string("\(error)")])
+                        self.failTasksAndCloseSubscriptions(with: error)
+                        context.fireErrorCaught(error)
+                        context.close(promise: nil)
+                        self.logger.error("Error during QoS 2 publish flow", metadata: ["mqtt_error": .string("\(error)")])
                     }
                 case .success:
-                    loopBoundChannelHandler.value.subscriptions.notify(message.publish)
+                    self.subscriptions.notify(message.publish)
                 }
             }
         }
@@ -418,21 +416,21 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                 // otherwise reschedule task
                 if channelHandler.lastPingreqEventTime + channelHandler.pingreqTimeout <= .now() {
                     guard context.channel.isActive else { return }
-                    let loopBoundContext = NIOLoopBound(context, eventLoop: eventLoop)
                     channelHandler.sendMessage(MQTTPingreqPacket()) { message in
                         guard message.type == .PINGRESP else { return false }
                         return true
                     }
+                    .assumeIsolated()
                     .whenComplete { result in
                         switch result {
                         case .failure(let error):
-                            self.channelHandler.value.failTasksAndCloseSubscriptions(with: error)
-                            loopBoundContext.value.fireErrorCaught(error)
+                            channelHandler.failTasksAndCloseSubscriptions(with: error)
+                            context.fireErrorCaught(error)
                         case .success:
                             break
                         }
-                        self.channelHandler.value.lastPingreqEventTime = .now()
-                        self.channelHandler.value.schedulePingreqCallback()
+                        channelHandler.lastPingreqEventTime = .now()
+                        channelHandler.schedulePingreqCallback()
                     }
                 } else {
                     channelHandler.schedulePingreqCallback()

--- a/Sources/MQTTNIO/Connection/MQTTConnection+v5.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection+v5.swift
@@ -15,7 +15,8 @@ import NIOCore
 
 extension MQTTConnection {
     /// Provides implementations of functions that expose MQTT Version 5.0 features.
-    public struct V5 {
+    public struct V5: Sendable {
+        @usableFromInline
         let connection: MQTTConnection
 
         /// Publish message to topic.

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -79,7 +79,6 @@ public final actor MQTTConnection: Sendable {
     ///   - cleanSession: Whether to start a clean session.
     ///   - eventLoop: EventLoop to run the connection on.
     ///   - logger: Logger to use for the connection.
-    ///   - isolation: Actor isolation.
     ///   - operation: Closure handling the MQTT connection.
     /// - Returns: Value returned from the operation closure.
     public static func withConnection<Value>(
@@ -89,7 +88,6 @@ public final actor MQTTConnection: Sendable {
         cleanSession: Bool = true,
         eventLoop: any EventLoop = MultiThreadedEventLoopGroup.singleton.any(),
         logger: Logger,
-        isolation: isolated (any Actor)? = #isolation,
         operation: (MQTTConnection) async throws -> sending Value
     ) async throws -> sending Value {
         let connection = try await self.connect(
@@ -232,9 +230,13 @@ public final actor MQTTConnection: Sendable {
                 }
             }
         let connection = try await future.get()
-        try await connection.channelHandler.waitOnInitialized().get()
+        try await connection.waitOnInitialized()
         _ = try await connection._connect(packet: packet)
         return connection
+    }
+
+    func waitOnInitialized() async throws {
+        try await self.channelHandler.waitOnInitialized().get()
     }
 
     /// Close connection
@@ -423,7 +425,7 @@ public final actor MQTTConnection: Sendable {
         configuration: MQTTConnectionConfiguration,
         webSocketConfiguration: MQTTConnectionConfiguration.WebSocketConfiguration,
         upgradePromise promise: EventLoopPromise<Void>,
-        afterHandlerAdded: @escaping () throws -> Void
+        afterHandlerAdded: @Sendable @escaping () throws -> Void
     ) -> EventLoopFuture<Void> {
         var hostHeader: String {
             switch (configuration.useSSL, address.value) {
@@ -459,7 +461,7 @@ public final actor MQTTConnection: Sendable {
             future.cascade(to: promise)
             return future
         }
-        let upgradeConfig: NIOHTTPClientUpgradeConfiguration = (
+        let upgradeConfig: NIOHTTPClientUpgradeSendableConfiguration = (
             upgraders: [websocketUpgrader],
             completionHandler: { _ in
                 channel.pipeline.removeHandler(httpHandler, promise: nil)

--- a/Sources/MQTTNIO/Subscriptions/MQTTConnection+subscribe.swift
+++ b/Sources/MQTTNIO/Subscriptions/MQTTConnection+subscribe.swift
@@ -18,14 +18,13 @@ extension MQTTConnection {
     ///
     /// - Parameters:
     ///   - subscriptions: Array of ``MQTTSubscribeInfo`` defining the subscriptions.
-    ///   - isolation: Actor isolation
     ///   - process: Closure where messages received from the subscription are processed.
     ///     The closure receives a ``MQTTSubscription`` `AsyncSequence` to listen for messages.
-    public func subscribe<Value>(
+    @inlinable
+    public nonisolated func subscribe<Value>(
         to subscriptions: [MQTTSubscribeInfo],
-        isolation: isolated (any Actor)? = #isolation,
-        process: (MQTTSubscription) async throws -> sending Value
-    ) async throws -> sending Value {
+        process: (MQTTSubscription) async throws -> Value
+    ) async throws -> Value {
         let (id, stream) = try await self.subscribe(to: subscriptions.map { .init(topicFilter: $0.topicFilter, qos: $0.qos) })
         let value: Value
         do {
@@ -45,6 +44,7 @@ extension MQTTConnection {
         return value
     }
 
+    @usableFromInline
     func subscribe(
         to subscriptions: [MQTTSubscribeInfoV5],
         properties: MQTTProperties = .init()
@@ -54,7 +54,7 @@ extension MQTTConnection {
             throw MQTTError.cancelledTask
         }
         let packet = MQTTSubscribePacket(subscriptions: subscriptions, properties: properties, packetId: self.updatePacketId())
-        let subscriptionID: UInt = try await withCheckedThrowingContinuation { continuation in
+        let subscriptionID: UInt = try await withCheckedThrowingContinuation(isolation: self) { continuation in
             self.channelHandler.subscribe(
                 streamContinuation: streamContinuation,
                 packet: packet,
@@ -64,6 +64,7 @@ extension MQTTConnection {
         return (subscriptionID, stream)
     }
 
+    @usableFromInline
     func unsubscribe(id: UInt, properties: MQTTProperties = .init()) async throws {
         try await withCheckedThrowingContinuation { continuation in
             self.channelHandler.unsubscribe(id: id, packetID: self.updatePacketId(), properties: properties, promise: .swift(continuation))
@@ -80,16 +81,15 @@ extension MQTTConnection.V5 {
     ///   - subscriptions: Array of ``MQTTSubscribeInfo`` defining the subscriptions.
     ///   - subscribeProperties: Properties to attach to the subscribe packet.
     ///   - unsubscribeProperties: Properties to attach to the unsubscribe packet.
-    ///   - isolation: Actor isolation
     ///   - process: Closure where messages received from the subscription are processed.
     ///     The closure receives a ``MQTTSubscription`` `AsyncSequence` to listen for messages.
-    public func subscribe<Value>(
+    @inlinable
+    public nonisolated func subscribe<Value>(
         to subscriptions: [MQTTSubscribeInfoV5],
         subscribeProperties: MQTTProperties = .init(),
         unsubscribeProperties: MQTTProperties = .init(),
-        isolation: isolated (any Actor)? = #isolation,
-        process: (MQTTSubscription) async throws -> sending Value
-    ) async throws -> sending Value {
+        process: (MQTTSubscription) async throws -> Value
+    ) async throws -> Value {
         let (id, stream) = try await self.connection.subscribe(to: subscriptions, properties: subscribeProperties)
         let value: Value
         do {

--- a/Sources/MQTTNIO/Subscriptions/MQTTConnection+subscribe.swift
+++ b/Sources/MQTTNIO/Subscriptions/MQTTConnection+subscribe.swift
@@ -54,7 +54,7 @@ extension MQTTConnection {
             throw MQTTError.cancelledTask
         }
         let packet = MQTTSubscribePacket(subscriptions: subscriptions, properties: properties, packetId: self.updatePacketId())
-        let subscriptionID: UInt32 = try await withCheckedThrowingContinuation(isolation: self) { continuation in
+        let subscriptionID: UInt32 = try await withCheckedThrowingContinuation { continuation in
             self.channelHandler.subscribe(
                 streamContinuation: streamContinuation,
                 packet: packet,

--- a/Sources/MQTTNIO/Subscriptions/MQTTSubscription.swift
+++ b/Sources/MQTTNIO/Subscriptions/MQTTSubscription.swift
@@ -35,16 +35,10 @@ public struct MQTTSubscription: AsyncSequence, Sendable {
     public struct AsyncIterator: AsyncIteratorProtocol {
         var base: BaseAsyncSequence.AsyncIterator
 
-        #if compiler(>=6.2)
         @concurrent
         public mutating func next() async throws -> Element? {
             try await self.base.next()
         }
-        #else
-        public mutating func next() async throws -> Element? {
-            try await self.base.next()
-        }
-        #endif
 
         public mutating func next(isolation actor: isolated (any Actor)?) async throws(any Error) -> MQTTPublishInfo? {
             try await self.base.next(isolation: actor)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   test:
-    image: swift:6.1
+    image: swift:6.2
     working_dir: /mqtt-nio
     volumes:
       - .:/mqtt-nio


### PR DESCRIPTION
- Bump `swift-tools-version` to 6.2
- Enable Swift 6 language mode and "NonisolatedNonsendingByDefault"
- Remove unused ping/pong code from WebSocketHandler that was causing warnings

There is a warning left in MQTTChannelHandler that right now I don't know how to solve and a few left in MQTTConnection that require a bit of restructuring (will do in a separate PR)

Resolves #188 