### PR TITLE
Fix handling of duplicate PUBLISH packets in QoS 2

### DIFF
--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
@@ -121,16 +121,18 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
         let buffer = self.unwrapInboundIn(data)
         do {
             try self.decoder.process(buffer: buffer) { message in
+                self.logger.trace(
+                    "MQTT In",
+                    metadata: ["mqtt_message": .stringConvertible(message), "mqtt_packet_id": .stringConvertible(message.packetId)]
+                )
                 switch self.stateMachine.receivedPacket(message) {
                 case .respondAndReturn:
                     let publishMessage = message as! MQTTPublishPacket
                     // publish logging includes topic name
                     self.logger.trace(
-                        "MQTT In",
+                        "MQTT Publish In",
                         metadata: [
-                            "mqtt_message": .stringConvertible(publishMessage),
-                            "mqtt_packet_id": .stringConvertible(publishMessage.packetId),
-                            "mqtt_topicName": .string(publishMessage.publish.topicName),
+                            "mqtt_topicName": .string(publishMessage.publish.topicName)
                         ]
                     )
                     self.respondToPublish(publishMessage, context: context)
@@ -153,10 +155,6 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                         return
                     }
                 }
-                self.logger.trace(
-                    "MQTT In",
-                    metadata: ["mqtt_message": .stringConvertible(message), "mqtt_packet_id": .stringConvertible(message.packetId)]
-                )
             }
         } catch {
             self.failTasksAndCloseSubscriptions(with: error)
@@ -182,6 +180,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
     /// If QoS is `.atLeastOnce` then send PUBACK
     /// If QoS is `.exactlyOnce` then send PUBREC, wait for PUBREL and then respond with PUBCOMP (in `respondToPubrel`)
     private func respondToPublish(_ message: MQTTPublishPacket, context: ChannelHandlerContext) {
+        struct DuplicatePublishError: Error {}
         switch message.publish.qos {
         case .atMostOnce:
             self.subscriptions.notify(message.publish)
@@ -210,10 +209,11 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                 requestID: MQTTConnection.requestIDGenerator.next()
             ) { newMessage in
                 guard newMessage.packetId == message.packetId else { return false }
-                // if we receive a publish message while waiting for a PUBREL from broker then replace data to be published and retry PUBREC
+                // if we receive a publish message while waiting for a PUBREL from server this is a
+                // duplicate. We need to reset the response and send a PUBREC again. Here we throw an error
+                // which is caught further down and at that trigger a new PUBREC
                 if newMessage.type == .PUBLISH {
-                    //publish = publishMessage.publish
-                    throw MQTTError.retrySend
+                    throw DuplicatePublishError()
                 }
                 // if we receive anything but a PUBREL then throw unexpected message
                 guard newMessage.type == .PUBREL else { throw MQTTError.unexpectedMessage }
@@ -226,8 +226,9 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                 switch result {
                 case .failure(let error):
                     switch error {
-                    case MQTTError.retrySend:
-                        // do not report retrySend error
+                    case is DuplicatePublishError:
+                        // ignore duplicate publish error and initiate the PUBLISH handshake again
+                        self.respondToPublish(message, context: context)
                         return
                     default:
                         self.failTasksAndCloseSubscriptions(with: error)

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
@@ -221,7 +221,6 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                 return true
             }
             .assumeIsolated()
-            //.map { _ in publish }
             .whenComplete { result in
                 switch result {
                 case .failure(let error):

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
@@ -202,8 +202,6 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                 }
 
         case .exactlyOnce:
-            // TODO: Investigate what to do if we receive a publish message while waiting for a PUBREL
-            //var publish = message.publish
             self.sendMessage(
                 MQTTPubAckPacket(type: .PUBREC, packetId: message.packetId),
                 requestID: MQTTConnection.requestIDGenerator.next()

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -344,8 +344,8 @@ struct MQTTConnectionTests {
     }
 
     @Test
-    func testSubscribeAndPublishQoS2MissedPUBREC() async throws {
-        var logger = Logger(label: "testSubscribeAndPublishQoS2MissedPUBREC")
+    func testSubscribeAndDuplicatePublishQoS2() async throws {
+        var logger = Logger(label: "testSubscribeAndDuplicatePublishQoS2")
         logger.logLevel = .trace
         try await testSubscribe(
             subscribeInfos: [.init(topicFilter: "testTopic", qos: .exactlyOnce)],

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -344,6 +344,64 @@ struct MQTTConnectionTests {
     }
 
     @Test
+    func testSubscribeAndPublishQoS2MissedPUBREC() async throws {
+        var logger = Logger(label: "testSubscribeAndPublishQoS2")
+        logger.logLevel = .trace
+        try await testSubscribe(
+            subscribeInfos: [.init(topicFilter: "testTopic", qos: .exactlyOnce)],
+            logger: logger
+        ) { sub in
+            var iterator = sub.makeAsyncIterator()
+            let event = try #require(try await iterator.next())
+            #expect(event.payload == ByteBuffer(string: "TestPayload"))
+        } server: { channel in
+            // send PUBLISH
+            let publish = MQTTPublishPacket(
+                publish: .init(
+                    qos: .exactlyOnce,
+                    retain: false,
+                    topicName: "testTopic",
+                    payload: ByteBuffer(string: "TestPayload"),
+                    properties: .init()
+                ),
+                packetId: 32768
+            )
+            try await channel.writeInboundPacket(publish, version: .v3_1_1)
+            // read PUBREC (We're going to ignore this)
+            var packet = try await channel.waitForOutboundPacket()
+            let pubAck = try MQTTPubAckPacket.read(version: .v3_1_1, from: packet)
+            #expect(pubAck.type == .PUBREC)
+            #expect(pubAck.packetId == publish.packetId)
+            // send PUBLISH again, as we never got a PUBREC
+            let publishDuplicate = MQTTPublishPacket(
+                publish: .init(
+                    qos: .exactlyOnce,
+                    retain: false,
+                    dup: true,
+                    topicName: "testTopic",
+                    payload: ByteBuffer(string: "TestPayload"),
+                    properties: .init()
+                ),
+                packetId: 32768
+            )
+            try await channel.writeInboundPacket(publishDuplicate, version: .v3_1_1)
+            // read PUBREC
+            packet = try await channel.waitForOutboundPacket()
+            let pubAck2 = try MQTTPubAckPacket.read(version: .v3_1_1, from: packet)
+            #expect(pubAck2.type == .PUBREC)
+            #expect(pubAck2.packetId == publish.packetId)
+            // write PUBREL
+            let pubRel = MQTTPubAckPacket(type: .PUBREL, packetId: pubAck.packetId)
+            try await channel.writeInboundPacket(pubRel, version: .v3_1_1)
+            // read PUBCOMP
+            packet = try await channel.waitForOutboundPacket()
+            let pubComp = try MQTTPubAckPacket.read(version: .v3_1_1, from: packet)
+            #expect(pubComp.type == .PUBCOMP)
+            #expect(pubComp.packetId == publish.packetId)
+        }
+    }
+
+    @Test
     func testTopicFilter() async throws {
         var logger = Logger(label: "testTopicFilter")
         logger.logLevel = .trace

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -345,7 +345,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testSubscribeAndPublishQoS2MissedPUBREC() async throws {
-        var logger = Logger(label: "testSubscribeAndPublishQoS2")
+        var logger = Logger(label: "testSubscribeAndPublishQoS2MissedPUBREC")
         logger.logLevel = .trace
         try await testSubscribe(
             subscribeInfos: [.init(topicFilter: "testTopic", qos: .exactlyOnce)],


### PR DESCRIPTION
If the server doesn't receive a PUBREC in time, it will send another PUBLISH tagged as a duplicate and will expect the PUBREC,PUBREL,PUBCOMP handshake to be repeated. Previously MQTTNIO was treating this as a complete new PUBLISH and the old PUBLISH was never completed. If this was repeated the task array could grow indefinitely.

To fix this now if a PUBLISH is tagged as a duplicate we check to see if there is already a PUBLISH with the same packet id being processed if so we pass the new PUBLISH to the associated MQTTTask. The task then will see it has received a PUBLISH when it was expecting a PUBREL. It will quit that task (by throwing an error) and restart the PUBREC,PUBREL,PUBCOMP handshake.

I also improved the performance of removing a task from the task array by copying the last task into the slot that was being removed, instead of calling `removeAll`