### PR TITLE
Authenticator method name

### DIFF
--- a/Sources/MQTTNIO/Connection/MQTTAuthenticator.swift
+++ b/Sources/MQTTNIO/Connection/MQTTAuthenticator.swift
@@ -12,5 +12,8 @@
 //===----------------------------------------------------------------------===//
 
 public protocol MQTTAuthenticator: Sendable {
+    /// Authentication method name passed from client to server and back in the authentication method property
+    var methodName: String { get }
+    /// Respond to AUTH packet sent from server.
     func authenticate(_ authPackage: MQTTAuthV5) async throws -> MQTTAuthV5
 }

--- a/Sources/MQTTNIO/Connection/MQTTConnection+v5.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection+v5.swift
@@ -45,7 +45,8 @@ extension MQTTConnection {
         /// Re-authenticate with server.
         ///
         /// - Parameters:
-        ///   - properties: Properties to attach to auth packet. Must include `authenticationMethod`.
+        ///   - properties: Properties to attach to auth packet. The `authenticationMethod` will be added by this function
+        ///     so there is no need to include it here.
         ///   - authWorkflow: Respond to auth packets from server.
         ///
         /// - Returns: Final auth packet returned from server.
@@ -64,6 +65,8 @@ extension MQTTConnection {
             else {
                 throw MQTTError.authWorkflowRequired
             }
+            var properties = properties
+            properties.append(.authenticationMethod(authWorkflow.methodName))
             let authPacket = MQTTAuthPacket(reason: .reAuthenticate, properties: properties)
             let reAuthResponse = try await self.connection.sendMessage(authPacket) { message in
                 guard message.type == .AUTH else { return false }

--- a/Sources/MQTTNIO/Connection/MQTTConnection+v5.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection+v5.swift
@@ -66,8 +66,9 @@ extension MQTTConnection {
                 throw MQTTError.authWorkflowRequired
             }
             var properties = properties
-            properties.append(.authenticationMethod(authWorkflow.methodName))
+            properties.addOrReplace(.authenticationMethod(authWorkflow.methodName))
             let authPacket = MQTTAuthPacket(reason: .reAuthenticate, properties: properties)
+            // Send AUTH
             let reAuthResponse = try await self.connection.sendMessage(authPacket) { message in
                 guard message.type == .AUTH else { return false }
                 return true
@@ -76,6 +77,7 @@ extension MQTTConnection {
             if authResponse.reason == .success {
                 return MQTTAuthV5(reason: authResponse.reason, properties: authResponse.properties)
             }
+            // Process AUTH response
             guard let auth = try await self.connection.processAuth(authResponse, authWorkflow: authWorkflow) as? MQTTAuthPacket else {
                 throw MQTTError.unexpectedMessage
             }

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -225,7 +225,7 @@ public final actor MQTTConnection: Sendable {
             }
         }
         if let authenticator {
-            properties.append(.authenticationMethod(authenticator.methodName))
+            properties.addOrReplace(.authenticationMethod(authenticator.methodName))
         }
         let packet = MQTTConnectPacket(
             cleanSession: cleanSession,
@@ -663,9 +663,12 @@ public final actor MQTTConnection: Sendable {
         authWorkflow: MQTTAuthenticator
     ) async throws -> any MQTTPacket {
         let auth = MQTTAuthV5(reason: packet.reason, properties: packet.properties)
+        // Authenticate
         var authResponse = try await authWorkflow.authenticate(auth)
+        // Add authentication name to response
         authResponse.properties.append(.authenticationMethod(authWorkflow.methodName))
         let responsePacket = MQTTAuthPacket(reason: authResponse.reason, properties: authResponse.properties)
+        // Send response
         let result = try await self.sendMessage(responsePacket) { message -> Bool in
             guard message.type == .CONNACK || message.type == .AUTH else { throw MQTTError.failedToConnect }
             return true

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -205,7 +205,7 @@ public final actor MQTTConnection: Sendable {
                 }
             }
         let authenticator: MQTTAuthenticator?
-        let properties: MQTTProperties
+        var properties: MQTTProperties
         (authenticator, properties) =
             switch configuration.versionConfiguration {
             case .v3_1_1:
@@ -224,7 +224,9 @@ public final actor MQTTConnection: Sendable {
                 }
             }
         }
-
+        if let authenticator {
+            properties.append(.authenticationMethod(authenticator.methodName))
+        }
         let packet = MQTTConnectPacket(
             cleanSession: cleanSession,
             keepAliveSeconds: UInt16(configuration.keepAliveInterval.nanoseconds / 1_000_000_000),
@@ -661,7 +663,8 @@ public final actor MQTTConnection: Sendable {
         authWorkflow: MQTTAuthenticator
     ) async throws -> any MQTTPacket {
         let auth = MQTTAuthV5(reason: packet.reason, properties: packet.properties)
-        let authResponse = try await authWorkflow.authenticate(auth)
+        var authResponse = try await authWorkflow.authenticate(auth)
+        authResponse.properties.append(.authenticationMethod(authWorkflow.methodName))
         let responsePacket = MQTTAuthPacket(reason: authResponse.reason, properties: authResponse.properties)
         let result = try await self.sendMessage(responsePacket) { message -> Bool in
             guard message.type == .CONNACK || message.type == .AUTH else { throw MQTTError.failedToConnect }

--- a/Sources/MQTTNIO/MQTTCoreTypes.swift
+++ b/Sources/MQTTNIO/MQTTCoreTypes.swift
@@ -45,22 +45,22 @@ public enum MQTTPacketType: UInt8, Sendable {
 /// MQTT PUBLISH packet parameters.
 public struct MQTTPublishInfo: Sendable {
     /// Quality of Service for message.
-    public let qos: MQTTQoS
+    public var qos: MQTTQoS
 
     /// Whether this is a retained message.
-    public let retain: Bool
+    public var retain: Bool
 
     /// Whether this is a duplicate publish message.
-    public let dup: Bool
+    public var dup: Bool
 
     /// Topic name on which the message is published.
-    public let topicName: String
+    public var topicName: String
 
     /// MQTT v5 properties
-    public let properties: MQTTProperties
+    public var properties: MQTTProperties
 
     /// Message payload.
-    public let payload: ByteBuffer
+    public var payload: ByteBuffer
 
     public init(
         qos: MQTTQoS,
@@ -84,10 +84,10 @@ public struct MQTTPublishInfo: Sendable {
 /// MQTT SUBSCRIBE packet parameters.
 public struct MQTTSubscribeInfo: Sendable {
     /// Topic filter to subscribe to.
-    public let topicFilter: String
+    public var topicFilter: String
 
     /// Quality of Service for subscription.
-    public let qos: MQTTQoS
+    public var qos: MQTTQoS
 
     public init(topicFilter: String, qos: MQTTQoS) {
         self.qos = qos

--- a/Sources/MQTTNIO/MQTTCoreTypesV5.swift
+++ b/Sources/MQTTNIO/MQTTCoreTypesV5.swift
@@ -14,11 +14,11 @@
 /// MQTT v5 Connack
 public struct MQTTConnackV5: Sendable {
     /// is using session state from previous session
-    public let sessionPresent: Bool
+    public var sessionPresent: Bool
     /// connect reason code
-    public let reason: MQTTReasonCode
+    public var reason: MQTTReasonCode
     /// properties
-    public let properties: MQTTProperties
+    public var properties: MQTTProperties
 }
 
 /// MQTT v5 ACK information. Returned with PUBACK, PUBREL
@@ -47,19 +47,19 @@ public struct MQTTSubscribeInfoV5: Sendable {
     }
 
     /// Topic filter to subscribe to.
-    public let topicFilter: String
+    public var topicFilter: String
 
     /// Quality of Service for subscription.
-    public let qos: MQTTQoS
+    public var qos: MQTTQoS
 
     /// Don't forward message published by this client
-    public let noLocal: Bool
+    public var noLocal: Bool
 
     /// Keep retain flag message was published with
-    public let retainAsPublished: Bool
+    public var retainAsPublished: Bool
 
     /// Retain handing
-    public let retainHandling: RetainHandling
+    public var retainHandling: RetainHandling
 
     public init(
         topicFilter: String,
@@ -81,9 +81,9 @@ public struct MQTTSubscribeInfoV5: Sendable {
 /// Contains data returned in subscribe/unsubscribe ack packets
 public struct MQTTSubackV5: Sendable {
     /// MQTT v5 subscription reason code
-    public let reasons: [MQTTReasonCode]
+    public var reasons: [MQTTReasonCode]
     /// MQTT v5 properties
-    public let properties: MQTTProperties
+    public var properties: MQTTProperties
 
     init(reasons: [MQTTReasonCode], properties: MQTTProperties = .init()) {
         self.reasons = reasons
@@ -98,9 +98,9 @@ public struct MQTTSubackV5: Sendable {
 /// authentication
 public struct MQTTAuthV5: Sendable {
     /// MQTT v5 authentication reason code
-    public let reason: MQTTReasonCode
+    public var reason: MQTTReasonCode
     /// MQTT v5 properties
-    public let properties: MQTTProperties
+    public var properties: MQTTProperties
 
     init(reason: MQTTReasonCode, properties: MQTTProperties) {
         self.reason = reason

--- a/Sources/MQTTNIO/MQTTProperties.swift
+++ b/Sources/MQTTNIO/MQTTProperties.swift
@@ -90,6 +90,16 @@ public struct MQTTProperties: Sendable, Equatable {
         self.properties.append(property)
     }
 
+    public mutating func addOrReplace(_ property: Property) {
+        for index in self.properties.indices {
+            if self.properties[index].id == property.id {
+                self.properties[index] = property
+                return
+            }
+        }
+        self.properties.append(property)
+    }
+
     var properties: [Property]
 }
 

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -348,6 +348,7 @@ struct IntegrationV5Tests {
             logger: self.logger
         ) { connection in
             struct EmptyAuthenticator: MQTTAuthenticator {
+                var methodName: String { "Empty" }
                 func authenticate(_ authPackage: MQTTAuthV5) async throws -> MQTTAuthV5 {
                     .init(reason: .continueAuthentication, properties: [])
                 }

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -50,7 +50,10 @@ struct MQTTConnectionTests {
                 let connect = try MQTTConnectPacket.read(version: configuration.version, from: packet)
                 #expect(connect.cleanSession == cleanSession)
                 #expect(connect.clientIdentifier == identifier)
-                if case .v5_0(let connectProperties, _, _, _) = configuration.versionConfiguration {
+                if case .v5_0(var connectProperties, _, _, let authWorkflow) = configuration.versionConfiguration {
+                    if let authWorkflow {
+                        connectProperties.append(.authenticationMethod(authWorkflow.methodName))
+                    }
                     #expect(connectProperties == connect.properties)
                 }
 
@@ -441,7 +444,8 @@ struct MQTTConnectionTests {
             group.addTask {
                 // wait for connect
                 var packet = try await channel.waitForOutboundPacket()
-                #expect(packet.type == .CONNECT)
+                let connect = try MQTTConnectPacket.read(version: .v5_0, from: packet)
+                #expect(connect.properties.contains(.authenticationMethod("Simple")))
                 // send auth
                 let auth = MQTTAuthPacket(reason: .continueAuthentication, properties: [.authenticationData(.init(string: "User"))])
                 try await channel.writeInboundPacket(auth, version: .v5_0)
@@ -449,6 +453,7 @@ struct MQTTConnectionTests {
                 packet = try await channel.waitForOutboundPacket()
                 let authResponsePacket = try MQTTAuthPacket.read(version: .v5_0, from: packet)
                 #expect(authResponsePacket.reason == .continueAuthentication)
+                #expect(authResponsePacket.properties.contains(.authenticationMethod("Simple")))
                 #expect(authResponsePacket.properties.contains(.authenticationData(ByteBuffer(string: "Password"))))
                 // send connack
                 let connack = MQTTConnAckPacket(returnCode: 0, acknowledgeFlags: 1, properties: .init())
@@ -477,6 +482,7 @@ struct MQTTConnectionTests {
             var packet = try await channel.waitForOutboundPacket()
             let initialAuth = try MQTTAuthPacket.read(version: .v5_0, from: packet)
             #expect(initialAuth.reason == .reAuthenticate)
+            #expect(initialAuth.properties.contains(.authenticationMethod("Simple")))
             // send auth
             let auth = MQTTAuthPacket(reason: .continueAuthentication, properties: [.authenticationData(.init(string: "User"))])
             try await channel.writeInboundPacket(auth, version: .v5_0)
@@ -485,6 +491,7 @@ struct MQTTConnectionTests {
             let authResponsePacket = try MQTTAuthPacket.read(version: .v5_0, from: packet)
             #expect(packet.type == .AUTH)
             #expect(authResponsePacket.reason == .continueAuthentication)
+            #expect(authResponsePacket.properties.contains(.authenticationMethod("Simple")))
             #expect(authResponsePacket.properties.contains(.authenticationData(ByteBuffer(string: "Password"))))
             // send final auth
             let finalAuth = MQTTAuthPacket(reason: .success, properties: [])

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -494,6 +494,7 @@ struct MQTTConnectionTests {
 }
 
 struct SimpleAuthWorkflow: MQTTAuthenticator {
+    var methodName: String { "Simple" }
     func authenticate(_ auth: MQTTAuthV5) async throws -> MQTTAuthV5 {
         switch auth.reason {
         case .continueAuthentication, .reAuthenticate:


### PR DESCRIPTION
Authentication methods need to have a name which is passed in with the CONNECT packet and any subsequent AUTH packets.

I made all the member variables of the core types vars as well. I need it for `MQTTAuthV5` but it made sense to do it for all of them. 