### PR TITLE
Fix Swift 6.3 sendability issues in connection setup

### DIFF
--- a/Sources/MQTTNIO/ChannelHandlers/MQTTTaskHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTTaskHandler.swift
@@ -14,7 +14,7 @@
 import NIO
 
 /// Task handler.
-final class MQTTTaskHandler: ChannelInboundHandler, RemovableChannelHandler {
+final class MQTTTaskHandler: @unchecked Sendable, ChannelInboundHandler, RemovableChannelHandler {
     typealias InboundIn = MQTTPacket
 
     var eventLoop: EventLoop!

--- a/Sources/MQTTNIO/MQTTConnection.swift
+++ b/Sources/MQTTNIO/MQTTConnection.swift
@@ -57,11 +57,6 @@ final class MQTTConnection {
                 .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
                 .connectTimeout(client.configuration.connectTimeout)
                 .channelInitializer { channel in
-                    // Work out what handlers to add
-                    let handlers: [ChannelHandler] = [
-                        MQTTMessageHandler(client, pingInterval: pingInterval),
-                        taskHandler,
-                    ]
                     // are we using websockets
                     if let webSocketConfiguration = client.configuration.webSocketConfiguration {
                         // prepare for websockets and on upgrade add handlers
@@ -75,10 +70,14 @@ final class MQTTConnection {
                             webSocketConfiguration: webSocketConfiguration,
                             upgradePromise: promise
                         ) {
-                            try channel.pipeline.syncOperations.addHandlers(handlers)
+                            try channel.pipeline.syncOperations.addHandler(MQTTMessageHandler(client, pingInterval: pingInterval))
+                            try channel.pipeline.syncOperations.addHandler(taskHandler)
                         }
                     } else {
-                        return channel.pipeline.addHandlers(handlers)
+                        return channel.pipeline.addHandlers([
+                            MQTTMessageHandler(client, pingInterval: pingInterval),
+                            taskHandler,
+                        ])
                     }
                 }
 

--- a/Sources/MQTTNIO/MQTTConnection.swift
+++ b/Sources/MQTTNIO/MQTTConnection.swift
@@ -161,7 +161,7 @@ final class MQTTConnection {
         channel: Channel,
         webSocketConfiguration: MQTTClient.WebSocketConfiguration,
         upgradePromise promise: EventLoopPromise<Void>,
-        afterHandlerAdded: @escaping () throws -> Void
+        afterHandlerAdded: @escaping @Sendable () throws -> Void
     ) -> EventLoopFuture<Void> {
         // initial HTTP request handler, before upgrade
         let httpHandler = WebSocketInitialRequestHandler(

--- a/Sources/MQTTNIO/TSTLSConfiguration.swift
+++ b/Sources/MQTTNIO/TSTLSConfiguration.swift
@@ -282,7 +282,7 @@ extension TSTLSConfiguration {
     }
 
     /// Dispatch queue used by Network framework TLS to control certificate verification
-    static var tlsDispatchQueue = DispatchQueue(label: "TSTLSConfiguration")
+    static let tlsDispatchQueue = DispatchQueue(label: "TSTLSConfiguration")
 }
 
 /// Deprecated TSTLSConfiguration


### PR DESCRIPTION
## Summary
- mark `MQTTTaskHandler` as `@unchecked Sendable` for event-loop confined use in `@Sendable` closures
- require `@Sendable` for websocket `afterHandlerAdded` callback
- make `TSTLSConfiguration.tlsDispatchQueue` immutable (`static let`)
- avoid capturing a non-Sendable `[ChannelHandler]` array in websocket setup by building handlers inline

## Backward compatibility
- This remains backward compatible for existing runtime behavior and public API usage: no wire protocol behavior changes, no MQTT semantic changes, and no required call-site changes for typical client usage.
- The changes are narrowly scoped to concurrency annotations/safety (`@Sendable`, `@unchecked Sendable`) and immutable static state, which are needed to satisfy Swift 6 strict-concurrency checks while preserving pre-Swift-6 behavior.

## Validation
- This patch unblocks Swift 6 strict concurrency errors seen from downstream app builds.
- Local `swift test` requires a running MQTT broker on localhost and fails without one (connection refused), so compile verification is based on downstream integration builds.