### PR TITLE
Implement `waitUntilNoActiveSubscriptions`

### DIFF
--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -250,6 +250,15 @@ public final actor MQTTConnection: Sendable {
         }
     }
 
+    /// Wait until there are no active subscriptions opened via this connection or via a ``MQTTSession`` associated with this connection.
+    ///
+    /// This function waits only for subscriptions that have been acknowledged by the server.
+    ///
+    /// If new subscriptions are opened while waiting, this function will also wait for those subscriptions to complete.
+    public func waitUntilNoActiveSubscriptions() async {
+        await self.session.waitUntilNoActiveSubscriptions()
+    }
+
     /// Connect to MQTT server and return the connection and whether there was a previous session present.
     ///
     /// - Parameters:

--- a/Sources/MQTTNIO/Session/MQTTSession.swift
+++ b/Sources/MQTTNIO/Session/MQTTSession.swift
@@ -138,8 +138,8 @@ extension MQTTSession {
                 }
                 self.logger.trace("Waiting for \(subscriptions.subscriptionIDMap.count) active subscriptions to complete")
                 subscriptions.emptySubscriptionsContinuations.append(continuation)
-                self.logger.trace("All active subscriptions completed")
             }
         }
+        self.logger.trace("All active subscriptions completed")
     }
 }

--- a/Sources/MQTTNIO/Session/MQTTSession.swift
+++ b/Sources/MQTTNIO/Session/MQTTSession.swift
@@ -134,6 +134,7 @@ extension MQTTSession {
             self.subscriptions.withLock { subscriptions in
                 if subscriptions.subscriptionIDMap.isEmpty {
                     self.logger.trace("No active subscriptions to wait for")
+                    continuation.resume()
                     return
                 }
                 self.logger.trace("Waiting for \(subscriptions.subscriptionIDMap.count) active subscriptions to complete")

--- a/Sources/MQTTNIO/Session/MQTTSession.swift
+++ b/Sources/MQTTNIO/Session/MQTTSession.swift
@@ -28,9 +28,14 @@ public final class MQTTSession: Sendable {
 
     let subscriptions: Mutex<MQTTSubscriptions>
 
+    /// See ``MQTTSession/waitUntilNoActiveSubscriptions()``
+    let emptySubscriptionsStream: AsyncStream<Void>
+
     let subscriptionsQueue: AsyncStream<SessionSubscriptionTask>
     @usableFromInline
     let subscriptionsQueueContinuation: AsyncStream<SessionSubscriptionTask>.Continuation
+
+    let logger: Logger
 
     /// Initialize a new ``MQTTSession`` with a unique client identifier.
     ///
@@ -48,9 +53,12 @@ public final class MQTTSession: Sendable {
     public init(clientID: String, logger: Logger) {
         self._clientID = .init(clientID)
         self.inflightPackets = .init(.init())
-        self.subscriptions = .init(.init(logger: logger))
+        let (emptySubscriptionsStream, emptySubscriptionsContinuation) = AsyncStream<Void>.makeStream()
+        self.subscriptions = .init(.init(logger: logger, emptySubscriptionsContinuation: emptySubscriptionsContinuation))
+        self.emptySubscriptionsStream = emptySubscriptionsStream
         self.isConnected = .init(false)
         (self.subscriptionsQueue, self.subscriptionsQueueContinuation) = AsyncStream.makeStream()
+        self.logger = logger
     }
 }
 
@@ -117,5 +125,22 @@ extension MQTTSession {
     enum SessionSubscriptionTask: Sendable {
         case subscribe(QueuedSubscription)
         case unsubscribe(QueuedUnsubscription)
+    }
+
+    /// Wait until there are no active subscriptions opened via this session or via any ``MQTTConnection``s using this session.
+    ///
+    /// This function waits only for subscriptions that have been acknowledged by the server,
+    /// so for example if a subscription is opened via this ``MQTTSession`` but the session is not passed to a ``MQTTConnection``,
+    /// this function will not wait for that subscription.
+    ///
+    /// If new subscriptions are opened while waiting, this function will also wait for those subscriptions to complete.
+    public func waitUntilNoActiveSubscriptions() async {
+        if self.subscriptions.withLock({ $0.subscriptionIDMap.isEmpty }) {
+            self.logger.trace("No active subscriptions to wait for")
+            return
+        }
+        self.logger.trace("Waiting for \(self.subscriptions.withLock { $0.subscriptionIDMap.count }) active subscriptions to complete")
+        await self.emptySubscriptionsStream.first(where: { _ in true })
+        self.logger.trace("All active subscriptions completed")
     }
 }

--- a/Sources/MQTTNIO/Session/MQTTSession.swift
+++ b/Sources/MQTTNIO/Session/MQTTSession.swift
@@ -28,9 +28,6 @@ public final class MQTTSession: Sendable {
 
     let subscriptions: Mutex<MQTTSubscriptions>
 
-    /// See ``MQTTSession/waitUntilNoActiveSubscriptions()``
-    let emptySubscriptionsStream: AsyncStream<Void>
-
     let subscriptionsQueue: AsyncStream<SessionSubscriptionTask>
     @usableFromInline
     let subscriptionsQueueContinuation: AsyncStream<SessionSubscriptionTask>.Continuation
@@ -53,9 +50,7 @@ public final class MQTTSession: Sendable {
     public init(clientID: String, logger: Logger) {
         self._clientID = .init(clientID)
         self.inflightPackets = .init(.init())
-        let (emptySubscriptionsStream, emptySubscriptionsContinuation) = AsyncStream<Void>.makeStream()
-        self.subscriptions = .init(.init(logger: logger, emptySubscriptionsContinuation: emptySubscriptionsContinuation))
-        self.emptySubscriptionsStream = emptySubscriptionsStream
+        self.subscriptions = .init(.init(logger: logger))
         self.isConnected = .init(false)
         (self.subscriptionsQueue, self.subscriptionsQueueContinuation) = AsyncStream.makeStream()
         self.logger = logger
@@ -135,12 +130,16 @@ extension MQTTSession {
     ///
     /// If new subscriptions are opened while waiting, this function will also wait for those subscriptions to complete.
     public func waitUntilNoActiveSubscriptions() async {
-        if self.subscriptions.withLock({ $0.subscriptionIDMap.isEmpty }) {
-            self.logger.trace("No active subscriptions to wait for")
-            return
+        await withCheckedContinuation { continuation in
+            self.subscriptions.withLock { subscriptions in
+                if subscriptions.subscriptionIDMap.isEmpty {
+                    self.logger.trace("No active subscriptions to wait for")
+                    return
+                }
+                self.logger.trace("Waiting for \(subscriptions.subscriptionIDMap.count) active subscriptions to complete")
+                subscriptions.emptySubscriptionsContinuations.append(continuation)
+                self.logger.trace("All active subscriptions completed")
+            }
         }
-        self.logger.trace("Waiting for \(self.subscriptions.withLock { $0.subscriptionIDMap.count }) active subscriptions to complete")
-        await self.emptySubscriptionsStream.first(where: { _ in true })
-        self.logger.trace("All active subscriptions completed")
     }
 }

--- a/Sources/MQTTNIO/Subscriptions/MQTTSubscriptions.swift
+++ b/Sources/MQTTNIO/Subscriptions/MQTTSubscriptions.swift
@@ -19,12 +19,16 @@ struct MQTTSubscriptions {
     var subscriptionMap: [TopicFilter: MQTTTopicStateMachine<SubscriptionRef>]
     let logger: Logger
 
+    /// See ``MQTTSession/waitUntilNoActiveSubscriptions()``
+    let emptySubscriptionsContinuation: AsyncStream<Void>.Continuation
+
     static let globalSubscriptionID = Atomic<UInt32>(0)
 
-    init(logger: Logger) {
+    init(logger: Logger, emptySubscriptionsContinuation: AsyncStream<Void>.Continuation) {
         self.subscriptionIDMap = [:]
         self.logger = logger
         self.subscriptionMap = [:]
+        self.emptySubscriptionsContinuation = emptySubscriptionsContinuation
     }
 
     /// We received a message
@@ -145,7 +149,13 @@ struct MQTTSubscriptions {
     /// If a message topic ends up with no subscriptions, then add it to the list of topics to unsubscribe from.
     mutating func unsubscribe(id: UInt32) -> UnsubscribeAction {
         guard let subscription = subscriptionIDMap[id] else { return .doNothing }
-        defer { self.subscriptionIDMap[id] = nil }
+        defer {
+            self.subscriptionIDMap[id] = nil
+            if self.subscriptionIDMap.isEmpty {
+                // See `MQTTSession.waitUntilNoActiveSubscriptions()`
+                self.emptySubscriptionsContinuation.yield()
+            }
+        }
         switch subscription.version {
         case .v3_1_1:
             var action: UnsubscribeAction = .doNothing

--- a/Sources/MQTTNIO/Subscriptions/MQTTSubscriptions.swift
+++ b/Sources/MQTTNIO/Subscriptions/MQTTSubscriptions.swift
@@ -20,15 +20,15 @@ struct MQTTSubscriptions {
     let logger: Logger
 
     /// See ``MQTTSession/waitUntilNoActiveSubscriptions()``
-    let emptySubscriptionsContinuation: AsyncStream<Void>.Continuation
+    var emptySubscriptionsContinuations: [CheckedContinuation<Void, Never>]
 
     static let globalSubscriptionID = Atomic<UInt32>(0)
 
-    init(logger: Logger, emptySubscriptionsContinuation: AsyncStream<Void>.Continuation) {
+    init(logger: Logger) {
         self.subscriptionIDMap = [:]
         self.logger = logger
         self.subscriptionMap = [:]
-        self.emptySubscriptionsContinuation = emptySubscriptionsContinuation
+        self.emptySubscriptionsContinuations = []
     }
 
     /// We received a message
@@ -153,7 +153,10 @@ struct MQTTSubscriptions {
             self.subscriptionIDMap[id] = nil
             if self.subscriptionIDMap.isEmpty {
                 // See `MQTTSession.waitUntilNoActiveSubscriptions()`
-                self.emptySubscriptionsContinuation.yield()
+                for continuation in self.emptySubscriptionsContinuations {
+                    continuation.resume()
+                }
+                self.emptySubscriptionsContinuations.removeAll()
             }
         }
         switch subscription.version {

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -1110,16 +1110,16 @@ struct IntegrationTests {
                             try await connection.publish(to: "wait/connection", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
                         }
 
+                        connectionGroup.addTask {
+                            // Wait until the subscriptions are active
+                            await waitStream.first { _ in true }
+
+                            await connection.waitUntilNoActiveSubscriptions()
+                        }
+
                         try await connectionGroup.waitForAll()
                     }
                 }
-            }
-
-            group.addTask {
-                // Wait until the subscriptions are active
-                await waitStream.first { _ in true }
-
-                await session.waitUntilNoActiveSubscriptions()
             }
 
             try await group.waitForAll()

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -1065,7 +1065,7 @@ struct IntegrationTests {
 
         try await withThrowingTaskGroup { group in
             let (connectionStream, connectionContinuation) = AsyncStream.makeStream(of: Void.self)
-            let (waitStream, waitContinuation) = AsyncStream.makeStream(of: Void.self)
+            let (sessionStream, sessionContinuation) = AsyncStream.makeStream(of: Void.self)
 
             group.addTask {
                 // Wait for the connection task to signal that the connection has been established before subscribing
@@ -1089,16 +1089,18 @@ struct IntegrationTests {
                     connectionContinuation.yield()
                     // Wait for the subscription to be established before publishing
                     try await Task.sleep(for: .milliseconds(100))
+                    // Signal that the session subscription is active
+                    sessionContinuation.yield()
 
                     try await withThrowingTaskGroup { connectionGroup in
                         let (publishStream, publishContinuation) = AsyncStream.makeStream(of: Void.self)
 
                         connectionGroup.addTask {
-                            try await connection.subscribe(to: [.init(topicFilter: "wait/connection", qos: .atLeastOnce)]) { subscription in
-                                // Signal that both the session and connection subscriptions are active
-                                waitContinuation.yield()
-                                publishContinuation.yield()
+                            // Wait for `waitUntilNoActiveSubscriptions` to be called
+                            try await Task.sleep(for: .milliseconds(100))
 
+                            try await connection.subscribe(to: [.init(topicFilter: "wait/connection", qos: .atLeastOnce)]) { subscription in
+                                publishContinuation.yield()
                                 var iterator = subscription.makeAsyncIterator()
                                 try #expect(await (iterator.next()?.payload).map { String(buffer: $0) } == "test")
                             }
@@ -1111,8 +1113,8 @@ struct IntegrationTests {
                         }
 
                         connectionGroup.addTask {
-                            // Wait until the subscriptions are active
-                            await waitStream.first { _ in true }
+                            // Wait until the session subscription is active
+                            await sessionStream.first { _ in true }
 
                             await connection.waitUntilNoActiveSubscriptions()
                         }

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -1048,6 +1048,84 @@ struct IntegrationTests {
         }
     }
 
+    @Test("Wait Until No Active Subscriptions")
+    func waitUntilNoActiveSubscriptions() async throws {
+        let logger = Logger(label: #function).withLogLevel(.trace)
+
+        // Make an initial connection with `cleanSession` to clear any existing session state
+        try await MQTTConnection.withConnection(
+            address: .hostname(Self.hostname),
+            identifier: "waitUntilNoActiveSubscriptions",
+            logger: logger
+        ) { connection in
+            try await connection.ping()
+        }
+
+        let session = MQTTSession(clientID: "waitUntilNoActiveSubscriptions", logger: logger)
+
+        try await withThrowingTaskGroup { group in
+            let (connectionStream, connectionContinuation) = AsyncStream.makeStream(of: Void.self)
+            let (waitStream, waitContinuation) = AsyncStream.makeStream(of: Void.self)
+
+            group.addTask {
+                // Wait for the connection task to signal that the connection has been established before subscribing
+                await connectionStream.first { _ in true }
+
+                try await session.subscribe(to: [.init(topicFilter: "wait/session", qos: .atLeastOnce)]) { subscription in
+                    var iterator = subscription.makeAsyncIterator()
+                    try #expect(await (iterator.next()?.payload).map { String(buffer: $0) } == "test")
+                }
+            }
+
+            group.addTask {
+                try await MQTTConnection.withConnection(
+                    address: .hostname(Self.hostname),
+                    session: session,
+                    logger: logger
+                ) { connection, sessionPresent in
+                    #expect(!sessionPresent)
+
+                    // Signal to the subscription task that the connection has been established and it can subscribe
+                    connectionContinuation.yield()
+                    // Wait for the subscription to be established before publishing
+                    try await Task.sleep(for: .milliseconds(100))
+
+                    try await withThrowingTaskGroup { connectionGroup in
+                        let (publishStream, publishContinuation) = AsyncStream.makeStream(of: Void.self)
+
+                        connectionGroup.addTask {
+                            try await connection.subscribe(to: [.init(topicFilter: "wait/connection", qos: .atLeastOnce)]) { subscription in
+                                // Signal that both the session and connection subscriptions are active
+                                waitContinuation.yield()
+                                publishContinuation.yield()
+
+                                var iterator = subscription.makeAsyncIterator()
+                                try #expect(await (iterator.next()?.payload).map { String(buffer: $0) } == "test")
+                            }
+                        }
+
+                        connectionGroup.addTask {
+                            await publishStream.first { _ in true }
+                            try await connection.publish(to: "wait/session", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
+                            try await connection.publish(to: "wait/connection", payload: ByteBuffer(string: "test"), qos: .atLeastOnce)
+                        }
+
+                        try await connectionGroup.waitForAll()
+                    }
+                }
+            }
+
+            group.addTask {
+                // Wait until the subscriptions are active
+                await waitStream.first { _ in true }
+
+                await session.waitUntilNoActiveSubscriptions()
+            }
+
+            try await group.waitForAll()
+        }
+    }
+
     static let rootPath = #filePath
         .split(separator: "/", omittingEmptySubsequences: false)
         .dropLast(3)

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -762,35 +762,18 @@ struct MQTTConnectionTests {
     @Test("Subscription with Session")
     func subscriptionWithSession() async throws {
         let logger = Logger(label: #function).withLogLevel(.trace)
-        let session = MQTTSession(clientID: "testClient", logger: logger)
+        let session = MQTTSession(clientID: "subscriptionWithSession", logger: logger)
 
-        let subscribeInfos = [MQTTSubscribeInfoV5(topicFilter: "testTopic", qos: .atLeastOnce)]
-
-        try await withTestMQTTServer(session: session, logger: logger) { connection in
-            try await session.subscribe(to: subscribeInfos) { sub in
-                var iterator = sub.makeAsyncIterator()
-                let event = try #require(try await iterator.next())
-                #expect(event.payload == ByteBuffer(string: "TestPayload"))
-            }
+        try await withTestSessionSubscription(
+            to: [.init(topicFilter: "testTopic", qos: .atLeastOnce)],
+            session: session,
+            logger: logger
+        ) { subscription in
+            var iterator = subscription.makeAsyncIterator()
+            let event = try #require(try await iterator.next())
+            #expect(event.payload == ByteBuffer(string: "TestPayload"))
         } server: { channel in
-            // receive SUBSCRIBE
-            var packet = try await channel.waitForOutboundPacket()
-            let subscribePacket = try MQTTSubscribePacket.read(version: .v3_1_1, from: packet)
-            #expect(subscribeInfos.count == subscribePacket.subscriptions.count)
-            for index in 0..<subscribePacket.subscriptions.count {
-                #expect(subscribePacket.subscriptions[index].topicFilter == subscribeInfos[index].topicFilter)
-                #expect(subscribePacket.subscriptions[index].qos == subscribeInfos[index].qos)
-            }
-            // send SUBACK
-            let suback = MQTTSubAckPacket(
-                type: .SUBACK,
-                packetId: subscribePacket.packetId,
-                reasons: subscribeInfos.map { _ in .success },
-                properties: .init()
-            )
-            try await channel.writeInboundPacket(suback, version: .v3_1_1)
-
-            // send PUBLISH
+            // Send PUBLISH
             let publish = MQTTPublishPacket(
                 publish: .init(
                     qos: .atLeastOnce,
@@ -802,24 +785,66 @@ struct MQTTConnectionTests {
                 packetId: 32768
             )
             try await channel.writeInboundPacket(publish, version: .v3_1_1)
-            // read PUBACK
+            // Read PUBACK
             let publishPacket = try await channel.waitForOutboundPacket()
             let pubAck = try MQTTPubAckPacket.read(version: .v3_1_1, from: publishPacket)
             #expect(pubAck.type == .PUBACK)
             #expect(pubAck.packetId == publish.packetId)
+        }
+    }
 
-            // receive UNSUBSCRIBE
-            packet = try await channel.waitForOutboundPacket()
-            let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v3_1_1, from: packet)
-            #expect(unsubscribePacket.subscriptions == subscribeInfos.map { $0.topicFilter })
-            // send SUBACK
-            let unsuback = MQTTSubAckPacket(
-                type: .UNSUBACK,
-                packetId: unsubscribePacket.packetId,
-                reasons: subscribeInfos.map { _ in .success },
-                properties: .init()
-            )
-            try await channel.writeInboundPacket(unsuback, version: .v3_1_1)
+    @Test("Wait Until No Active Subscriptions")
+    func waitUntilNoActiveSubscriptions() async throws {
+        let logger = Logger(label: #function).withLogLevel(.trace)
+        let session = MQTTSession(clientID: "waitUntilNoActiveSubscriptions", logger: logger)
+
+        let subscribeInfos: [[MQTTSubscribeInfoV5]] = [
+            [.init(topicFilter: "testTopic1", qos: .atMostOnce)],
+            [.init(topicFilter: "testTopic2", qos: .atMostOnce)],
+            [.init(topicFilter: "testTopic3", qos: .atMostOnce)],
+        ]
+
+        try await withThrowingTaskGroup { group in
+            let (stream, continuation) = AsyncStream.makeStream(of: Void.self)
+
+            group.addTask {
+                try await withTestSessionSubscriptions(
+                    to: subscribeInfos,
+                    session: session,
+                    logger: logger
+                ) { subscription in
+                    var iterator = subscription.makeAsyncIterator()
+                    let event = try #require(try await iterator.next())
+                    #expect(event.payload == ByteBuffer(string: "TestPayload"))
+                } server: { channel in
+                    // Signal that all subscriptions are active
+                    continuation.yield()
+
+                    for subscribeInfo in subscribeInfos {
+                        // Send PUBLISH
+                        let publish = MQTTPublishPacket(
+                            publish: .init(
+                                qos: .atMostOnce,
+                                retain: false,
+                                topicName: subscribeInfo.first!.topicFilter,
+                                payload: ByteBuffer(string: "TestPayload"),
+                                properties: .init()
+                            ),
+                            packetId: 32768
+                        )
+                        try await channel.writeInboundPacket(publish, version: .v3_1_1)
+                    }
+                }
+            }
+
+            group.addTask {
+                // Wait until all subscriptions are active
+                await stream.first { _ in true }
+
+                await session.waitUntilNoActiveSubscriptions()
+            }
+
+            try await group.waitForAll()
         }
     }
 }

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -772,6 +772,7 @@ struct MQTTConnectionTests {
             var iterator = subscription.makeAsyncIterator()
             let event = try #require(try await iterator.next())
             #expect(event.payload == ByteBuffer(string: "TestPayload"))
+        } client: { _ in
         } server: { channel in
             // Send PUBLISH
             let publish = MQTTPublishPacket(
@@ -804,47 +805,39 @@ struct MQTTConnectionTests {
             [.init(topicFilter: "testTopic3", qos: .atMostOnce)],
         ]
 
-        try await withThrowingTaskGroup { group in
-            let (stream, continuation) = AsyncStream.makeStream(of: Void.self)
+        let (stream, continuation) = AsyncStream.makeStream(of: Void.self)
 
-            group.addTask {
-                try await withTestSessionSubscriptions(
-                    to: subscribeInfos,
-                    session: session,
-                    logger: logger
-                ) { subscription in
-                    var iterator = subscription.makeAsyncIterator()
-                    let event = try #require(try await iterator.next())
-                    #expect(event.payload == ByteBuffer(string: "TestPayload"))
-                } server: { channel in
-                    // Signal that all subscriptions are active
-                    continuation.yield()
+        try await withTestSessionSubscriptions(
+            to: subscribeInfos,
+            session: session,
+            logger: logger
+        ) { subscription in
+            var iterator = subscription.makeAsyncIterator()
+            let event = try #require(try await iterator.next())
+            #expect(event.payload == ByteBuffer(string: "TestPayload"))
+        } client: { connection in
+            // Wait until all subscriptions are active
+            await stream.first { _ in true }
 
-                    for subscribeInfo in subscribeInfos {
-                        // Send PUBLISH
-                        let publish = MQTTPublishPacket(
-                            publish: .init(
-                                qos: .atMostOnce,
-                                retain: false,
-                                topicName: subscribeInfo.first!.topicFilter,
-                                payload: ByteBuffer(string: "TestPayload"),
-                                properties: .init()
-                            ),
-                            packetId: 32768
-                        )
-                        try await channel.writeInboundPacket(publish, version: .v3_1_1)
-                    }
-                }
+            await connection.waitUntilNoActiveSubscriptions()
+        } server: { channel in
+            // Signal that all subscriptions are active
+            continuation.yield()
+
+            for subscribeInfo in subscribeInfos {
+                // Send PUBLISH
+                let publish = MQTTPublishPacket(
+                    publish: .init(
+                        qos: .atMostOnce,
+                        retain: false,
+                        topicName: subscribeInfo.first!.topicFilter,
+                        payload: ByteBuffer(string: "TestPayload"),
+                        properties: .init()
+                    ),
+                    packetId: 32768
+                )
+                try await channel.writeInboundPacket(publish, version: .v3_1_1)
             }
-
-            group.addTask {
-                // Wait until all subscriptions are active
-                await stream.first { _ in true }
-
-                await session.waitUntilNoActiveSubscriptions()
-            }
-
-            try await group.waitForAll()
         }
     }
 }

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -840,6 +840,15 @@ struct MQTTConnectionTests {
             }
         }
     }
+
+    @Test("Wait with No Active Subscriptions")
+    func waitWithNoActiveSubscriptions() async throws {
+        try await withTestMQTTServer(logger: Logger(label: #function).withLogLevel(.trace)) { connection in
+            // Should return immediately as there are no active subscriptions
+            await connection.waitUntilNoActiveSubscriptions()
+        } server: { _ in
+        }
+    }
 }
 
 struct SimpleAuthWorkflow: MQTTAuthenticator {

--- a/Tests/MQTTNIOTests/MQTTSubscriptionsTests.swift
+++ b/Tests/MQTTNIOTests/MQTTSubscriptionsTests.swift
@@ -20,7 +20,10 @@ import Testing
 struct MQTTSubscriptionsTests {
     @Test("Subscribe and Unsubscribe")
     func subscribeAndUnsubscribe() throws {
-        var subscriptions = MQTTSubscriptions(logger: Logger(label: #function).withLogLevel(.trace))
+        var subscriptions = MQTTSubscriptions(
+            logger: Logger(label: #function).withLogLevel(.trace),
+            emptySubscriptionsContinuation: AsyncStream.makeStream().continuation
+        )
         let subscribeInfos = [
             MQTTSubscribeInfoV5(topicFilter: "test/topic/1", qos: .atMostOnce),
             MQTTSubscribeInfoV5(topicFilter: "test/topic/2/#", qos: .atLeastOnce),
@@ -60,7 +63,10 @@ struct MQTTSubscriptionsTests {
 
     @Test("Subscribe and Remove Subscription")
     func subscribeAndRemove() throws {
-        var subscriptions = MQTTSubscriptions(logger: Logger(label: #function).withLogLevel(.trace))
+        var subscriptions = MQTTSubscriptions(
+            logger: Logger(label: #function).withLogLevel(.trace),
+            emptySubscriptionsContinuation: AsyncStream.makeStream().continuation
+        )
         let subscribeInfos = [
             MQTTSubscribeInfoV5(topicFilter: "test/topic/1", qos: .atMostOnce),
             MQTTSubscribeInfoV5(topicFilter: "test/topic/2/#", qos: .atLeastOnce),

--- a/Tests/MQTTNIOTests/MQTTSubscriptionsTests.swift
+++ b/Tests/MQTTNIOTests/MQTTSubscriptionsTests.swift
@@ -20,10 +20,7 @@ import Testing
 struct MQTTSubscriptionsTests {
     @Test("Subscribe and Unsubscribe")
     func subscribeAndUnsubscribe() throws {
-        var subscriptions = MQTTSubscriptions(
-            logger: Logger(label: #function).withLogLevel(.trace),
-            emptySubscriptionsContinuation: AsyncStream.makeStream().continuation
-        )
+        var subscriptions = MQTTSubscriptions(logger: Logger(label: #function).withLogLevel(.trace))
         let subscribeInfos = [
             MQTTSubscribeInfoV5(topicFilter: "test/topic/1", qos: .atMostOnce),
             MQTTSubscribeInfoV5(topicFilter: "test/topic/2/#", qos: .atLeastOnce),
@@ -63,10 +60,7 @@ struct MQTTSubscriptionsTests {
 
     @Test("Subscribe and Remove Subscription")
     func subscribeAndRemove() throws {
-        var subscriptions = MQTTSubscriptions(
-            logger: Logger(label: #function).withLogLevel(.trace),
-            emptySubscriptionsContinuation: AsyncStream.makeStream().continuation
-        )
+        var subscriptions = MQTTSubscriptions(logger: Logger(label: #function).withLogLevel(.trace))
         let subscribeInfos = [
             MQTTSubscribeInfoV5(topicFilter: "test/topic/1", qos: .atMostOnce),
             MQTTSubscribeInfoV5(topicFilter: "test/topic/2/#", qos: .atLeastOnce),

--- a/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
+++ b/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
@@ -1,0 +1,98 @@
+import Logging
+import NIOCore
+import NIOEmbedded
+import Testing
+
+@testable import MQTTNIO
+
+extension MQTTConnectionTests {
+    /// Helper function to test multiple ``MQTTSession`` subscriptions with a test MQTT server.
+    ///
+    /// For each array of ``MQTTSubscribeInfoV5``, a session subscription will be created
+    /// and the same `clientOperation` and `serverOperation` will be performed for each subscription.
+    ///
+    /// - Parameters:
+    ///   - subscribeInfos: An array of arrays of ``MQTTSubscribeInfoV5`` to subscribe to.
+    ///         Each inner array represents a separate subscription.
+    ///   - session: The ``MQTTSession`` to use for opening the subscriptions.
+    ///   - logger: The logger to use for the test MQTT server.
+    ///   - clientOperation: An async operation to perform for each subscription opened via the session.
+    ///         The opened subscription will be passed as a parameter to this operation.
+    ///   - serverOperation: An async operation to perform for each subscription on the server side.
+    ///         The test MQTT server channel will be passed as a parameter to this operation.
+    func withTestSessionSubscriptions(
+        to subscribeInfos: [[MQTTSubscribeInfoV5]],
+        session: MQTTSession,
+        logger: Logger,
+        client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
+        server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
+    ) async throws {
+        try await withTestMQTTServer(session: session, logger: logger) { connection in
+            await withThrowingTaskGroup { group in
+                for subscribeInfo in subscribeInfos {
+                    group.addTask {
+                        try await session.subscribe(to: subscribeInfo) { subscription in
+                            try await clientOperation(subscription)
+                        }
+                    }
+                }
+            }
+        } server: { channel in
+            for _ in subscribeInfos {
+                // Receive SUBSCRIBE
+                let packet = try await channel.waitForOutboundPacket()
+                let subscribePacket = try MQTTSubscribePacket.read(version: .v3_1_1, from: packet)
+                // Send SUBACK
+                let suback = MQTTSubAckPacket(
+                    type: .SUBACK,
+                    packetId: subscribePacket.packetId,
+                    reasons: subscribeInfos.map { _ in .success },
+                    properties: .init()
+                )
+                try await channel.writeInboundPacket(suback, version: .v3_1_1)
+            }
+
+            try await serverOperation(channel)
+
+            for _ in subscribeInfos {
+                // Receive UNSUBSCRIBE
+                let packet = try await channel.waitForOutboundPacket()
+                let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v3_1_1, from: packet)
+                // Send UNSUBACK
+                let unsuback = MQTTSubAckPacket(
+                    type: .UNSUBACK,
+                    packetId: unsubscribePacket.packetId,
+                    reasons: subscribeInfos.map { _ in .success },
+                    properties: .init()
+                )
+                try await channel.writeInboundPacket(unsuback, version: .v3_1_1)
+            }
+        }
+    }
+
+    /// Helper function to test a ``MQTTSession`` subscription with a test MQTT server.
+    ///
+    /// - Parameters:
+    ///   - subscribeInfos: An array of ``MQTTSubscribeInfoV5`` to subscribe to for this subscription.
+    ///   - session: The ``MQTTSession`` to use for opening the subscription.
+    ///   - logger: The logger to use for the test MQTT server.
+    ///   - clientOperation: An async operation to perform for the subscription opened via the session.
+    ///         The opened subscription will be passed as a parameter to this operation.
+    ///   - serverOperation: An async operation to perform for the subscription on the server side.
+    ///         The test MQTT server channel will be passed as a parameter to this operation.
+    func withTestSessionSubscription(
+        to subscribeInfos: [MQTTSubscribeInfoV5],
+        session: MQTTSession,
+        logger: Logger,
+        client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
+        server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
+    ) async throws {
+        try await withTestSessionSubscriptions(
+            to: [subscribeInfos],
+            session: session,
+            logger: logger,
+            client: clientOperation,
+            server: serverOperation
+        )
+    }
+}

--- a/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
+++ b/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
@@ -16,23 +16,27 @@ extension MQTTConnectionTests {
     ///         Each inner array represents a separate subscription.
     ///   - session: The ``MQTTSession`` to use for opening the subscriptions.
     ///   - logger: The logger to use for the test MQTT server.
-    ///   - clientOperation: An async operation to perform for each subscription opened via the session.
+    ///   - subscribeOperation: An async operation to perform for each subscription opened via the session.
     ///         The opened subscription will be passed as a parameter to this operation.
+    ///   - clientOperation: An async operation to perform for the client side of the test.
+    ///         The ``MQTTConnection`` will be passed as a parameter to this operation.
     ///   - serverOperation: An async operation to perform for each subscription on the server side.
     ///         The test MQTT server channel will be passed as a parameter to this operation.
     func withTestSessionSubscriptions(
         to subscribeInfos: [[MQTTSubscribeInfoV5]],
         session: MQTTSession,
         logger: Logger,
-        client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
+        subscribe subscribeOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
+        client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
     ) async throws {
         try await withTestMQTTServer(session: session, logger: logger) { connection in
             await withThrowingTaskGroup { group in
+                group.addTask { try await clientOperation(connection) }
                 for subscribeInfo in subscribeInfos {
                     group.addTask {
                         try await session.subscribe(to: subscribeInfo) { subscription in
-                            try await clientOperation(subscription)
+                            try await subscribeOperation(subscription)
                         }
                     }
                 }
@@ -76,21 +80,25 @@ extension MQTTConnectionTests {
     ///   - subscribeInfos: An array of ``MQTTSubscribeInfoV5`` to subscribe to for this subscription.
     ///   - session: The ``MQTTSession`` to use for opening the subscription.
     ///   - logger: The logger to use for the test MQTT server.
-    ///   - clientOperation: An async operation to perform for the subscription opened via the session.
+    ///   - subscribeOperation: An async operation to perform for the subscription opened via the session.
     ///         The opened subscription will be passed as a parameter to this operation.
+    ///   - clientOperation: An async operation to perform for the client side of the test.
+    ///         The ``MQTTConnection`` will be passed as a parameter to this operation.
     ///   - serverOperation: An async operation to perform for the subscription on the server side.
     ///         The test MQTT server channel will be passed as a parameter to this operation.
     func withTestSessionSubscription(
         to subscribeInfos: [MQTTSubscribeInfoV5],
         session: MQTTSession,
         logger: Logger,
-        client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
+        subscribe subscribeOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
+        client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
     ) async throws {
         try await withTestSessionSubscriptions(
             to: [subscribeInfos],
             session: session,
             logger: logger,
+            subscribe: subscribeOperation,
             client: clientOperation,
             server: serverOperation
         )


### PR DESCRIPTION
Adds a method on `MQTTSession` that waits until there are no active subscriptions opened via the session or via any `MQTTConnection`s using the session.

I implemented it on `MQTTSession` since IMHO that is its natural place from a code perspective, but we can easily add a wrapper on `MQTTConnection` if you prefer.