### PR TITLE
v3: Refactor testing helpers

### DIFF
--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -19,7 +19,7 @@ import NIOPosix
 import Synchronization
 import Testing
 
-@testable public import MQTTNIO
+@testable import MQTTNIO
 
 #if canImport(Network)
 import NIOTransportServices
@@ -1146,49 +1146,5 @@ struct IntegrationTests {
         static func read(version: MQTTConnectionConfiguration.Version, from packet: MQTTIncomingPacket) throws -> Self {
             throw InternalError.notImplemented
         }
-    }
-}
-
-extension MQTTError: Equatable {
-    public static func == (lhs: MQTTError, rhs: MQTTError) -> Bool {
-        switch (lhs, rhs) {
-        case (.failedToConnect, .failedToConnect),
-            (.connectionClosed, .connectionClosed),
-            (.serverClosedConnection, .serverClosedConnection),
-            (.unexpectedMessage, .unexpectedMessage),
-            (.decodeError, .decodeError),
-            (.websocketUpgradeFailed, .websocketUpgradeFailed),
-            (.timeout, .timeout),
-            (.retrySend, .retrySend),
-            (.wrongTLSConfig, .wrongTLSConfig),
-            (.badResponse, .badResponse),
-            (.unrecognisedPacketType, .unrecognisedPacketType),
-            (.authWorkflowRequired, .authWorkflowRequired),
-            (.cancelledTask, .cancelledTask),
-            (.packetTooLarge, .packetTooLarge),
-            (.alreadyConnectedWithSession, .alreadyConnectedWithSession),
-            (.noSessionPresent, .noSessionPresent):
-            true
-        case (.connectionError(let lhsValue), .connectionError(let rhsValue)):
-            lhsValue == rhsValue
-        case (.reasonError(let lhsValue), .reasonError(let rhsValue)):
-            lhsValue == rhsValue
-        case (.serverDisconnection(let lhsValue), .serverDisconnection(let rhsValue)):
-            lhsValue.reason == rhsValue.reason && lhsValue.properties == rhsValue.properties
-        case (.versionMismatch(let expectedLHS, let actualLHS), .versionMismatch(let expectedRHS, let actualRHS)):
-            expectedLHS == expectedRHS && actualLHS == actualRHS
-        case (.invalidTopicFilter(let lhsValue), .invalidTopicFilter(let rhsValue)):
-            lhsValue == rhsValue
-        default:
-            false
-        }
-    }
-}
-
-extension Logger {
-    func withLogLevel(_ logLevel: Logger.Level) -> Logger {
-        var logger = self
-        logger.logLevel = logLevel
-        return logger
     }
 }

--- a/Tests/IntegrationTests/Utils/Logger+withLogLevel.swift
+++ b/Tests/IntegrationTests/Utils/Logger+withLogLevel.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the MQTTNIO project
+//
+// Copyright (c) 2020-2026 Adam Fowler
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+
+extension Logger {
+    func withLogLevel(_ logLevel: Logger.Level) -> Logger {
+        var logger = self
+        logger.logLevel = logLevel
+        return logger
+    }
+}

--- a/Tests/IntegrationTests/Utils/MQTTError+Equatable.swift
+++ b/Tests/IntegrationTests/Utils/MQTTError+Equatable.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the MQTTNIO project
+//
+// Copyright (c) 2020-2026 Adam Fowler
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable public import MQTTNIO
+
+extension MQTTError: Equatable {
+    public static func == (lhs: MQTTError, rhs: MQTTError) -> Bool {
+        switch (lhs, rhs) {
+        case (.failedToConnect, .failedToConnect),
+            (.connectionClosed, .connectionClosed),
+            (.serverClosedConnection, .serverClosedConnection),
+            (.unexpectedMessage, .unexpectedMessage),
+            (.decodeError, .decodeError),
+            (.websocketUpgradeFailed, .websocketUpgradeFailed),
+            (.timeout, .timeout),
+            (.retrySend, .retrySend),
+            (.wrongTLSConfig, .wrongTLSConfig),
+            (.badResponse, .badResponse),
+            (.unrecognisedPacketType, .unrecognisedPacketType),
+            (.authWorkflowRequired, .authWorkflowRequired),
+            (.cancelledTask, .cancelledTask),
+            (.packetTooLarge, .packetTooLarge),
+            (.alreadyConnectedWithSession, .alreadyConnectedWithSession),
+            (.noSessionPresent, .noSessionPresent):
+            true
+        case (.connectionError(let lhsValue), .connectionError(let rhsValue)):
+            lhsValue == rhsValue
+        case (.reasonError(let lhsValue), .reasonError(let rhsValue)):
+            lhsValue == rhsValue
+        case (.serverDisconnection(let lhsValue), .serverDisconnection(let rhsValue)):
+            lhsValue.reason == rhsValue.reason && lhsValue.properties == rhsValue.properties
+        case (.versionMismatch(let expectedLHS, let actualLHS), .versionMismatch(let expectedRHS, let actualRHS)):
+            expectedLHS == expectedRHS && actualLHS == actualRHS
+        case (.invalidTopicFilter(let lhsValue), .invalidTopicFilter(let rhsValue)):
+            lhsValue == rhsValue
+        default:
+            false
+        }
+    }
+}

--- a/Tests/MQTTNIOTests/CoreMQTTTests.swift
+++ b/Tests/MQTTNIOTests/CoreMQTTTests.swift
@@ -14,7 +14,7 @@
 import NIOCore
 import Testing
 
-@testable public import MQTTNIO
+@testable import MQTTNIO
 
 @Suite("Core MQTT Tests")
 struct CoreMQTTTests {
@@ -123,41 +123,5 @@ struct CoreMQTTTests {
         #expect(subscriptionMap[topicName: "sport"].count == 2)
         #expect(subscriptionMap[topicName: "sport/"].count == 3)
         #expect(subscriptionMap[topicName: "/finance"].count == 3)
-    }
-}
-
-extension MQTTError: Equatable {
-    public static func == (lhs: MQTTError, rhs: MQTTError) -> Bool {
-        switch (lhs, rhs) {
-        case (.failedToConnect, .failedToConnect),
-            (.connectionClosed, .connectionClosed),
-            (.serverClosedConnection, .serverClosedConnection),
-            (.unexpectedMessage, .unexpectedMessage),
-            (.decodeError, .decodeError),
-            (.websocketUpgradeFailed, .websocketUpgradeFailed),
-            (.timeout, .timeout),
-            (.retrySend, .retrySend),
-            (.wrongTLSConfig, .wrongTLSConfig),
-            (.badResponse, .badResponse),
-            (.unrecognisedPacketType, .unrecognisedPacketType),
-            (.authWorkflowRequired, .authWorkflowRequired),
-            (.cancelledTask, .cancelledTask),
-            (.packetTooLarge, .packetTooLarge),
-            (.alreadyConnectedWithSession, .alreadyConnectedWithSession),
-            (.noSessionPresent, .noSessionPresent):
-            true
-        case (.connectionError(let lhsValue), .connectionError(let rhsValue)):
-            lhsValue == rhsValue
-        case (.reasonError(let lhsValue), .reasonError(let rhsValue)):
-            lhsValue == rhsValue
-        case (.serverDisconnection(let lhsValue), .serverDisconnection(let rhsValue)):
-            lhsValue.reason == rhsValue.reason && lhsValue.properties == rhsValue.properties
-        case (.versionMismatch(let expectedLHS, let actualLHS), .versionMismatch(let expectedRHS, let actualRHS)):
-            expectedLHS == expectedRHS && actualLHS == actualRHS
-        case (.invalidTopicFilter(let lhsValue), .invalidTopicFilter(let rhsValue)):
-            lhsValue == rhsValue
-        default:
-            false
-        }
     }
 }

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -11,7 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import NIOCore
 import NIOEmbedded
@@ -22,171 +21,6 @@ import Testing
 
 @Suite("MQTTConnection Tests")
 struct MQTTConnectionTests {
-    func withTestMQTTServer(
-        configuration: MQTTConnectionConfiguration = .init(),
-        session: MQTTSession = MQTTSession(clientID: "", logger: Logger(label: "test_session")),
-        logger: Logger,
-        connackProperties: MQTTProperties = .init(),
-        client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
-        server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void,
-    ) async throws {
-        let channel = NIOAsyncTestingChannel()
-        let connection = try await MQTTConnection.setupChannelAndConnect(
-            channel,
-            configuration: configuration,
-            session: session,
-            logger: logger
-        )
-        let version = configuration.version
-        return try await withThrowingTaskGroup { group in
-            group.addTask {
-                do {
-                    _ = try await connection.sendConnect(clientID: session.clientID, cleanSession: session.clientID.isEmpty)
-                    try await withThrowingTaskGroup { group in
-                        group.addTask { try await connection.handleSessionSubscriptionTasks() }
-                        defer { group.cancelAll() }
-                        try await clientOperation(connection)
-                    }
-                    await connection.saveInflightToSession()
-                    connection.close()
-                } catch {
-                    await connection.saveInflightToSession()
-                    connection.close()
-                    throw error
-                }
-            }
-            group.addTask {
-                // wait for connect
-                let packet = try await channel.waitForOutboundPacket()
-                let connect = try MQTTConnectPacket.read(version: configuration.version, from: packet)
-                #expect(connect.cleanSession == session.clientID.isEmpty)
-                #expect(connect.clientIdentifier == session.clientID)
-                if case .v5_0(var connectProperties, _, _, let authWorkflow) = configuration.versionConfiguration {
-                    if let authWorkflow {
-                        connectProperties.append(.authenticationMethod(authWorkflow.methodName))
-                    }
-                    #expect(connectProperties == connect.properties)
-                }
-
-                let connack = MQTTConnAckPacket(returnCode: 0, acknowledgeFlags: 1, properties: connackProperties)
-                try await channel.writeInboundPacket(connack, version: version)
-
-                try await serverOperation(channel)
-
-                // wait for disconnect
-                let disconnectPacket = try await channel.waitForOutboundPacket()
-                #expect(disconnectPacket.type == .DISCONNECT)
-                #expect(disconnectPacket.packetId == 0)
-            }
-            try await group.waitForAll()
-        }
-    }
-
-    func testSubscribe(
-        subscribeInfos: [MQTTSubscribeInfo],
-        cleanSession: Bool = true,
-        identifier: String = UUID().uuidString,
-        logger: Logger,
-        client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
-        server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void,
-    ) async throws {
-        try await withTestMQTTServer(logger: logger) { connection in
-            try await connection.subscribe(to: subscribeInfos) { sub in
-                try await clientOperation(sub)
-            }
-        } server: { channel in
-            // receive SUBSCRIBE
-            var packet = try await channel.waitForOutboundPacket()
-            let subscribePacket = try MQTTSubscribePacket.read(version: .v3_1_1, from: packet)
-            #expect(subscribeInfos.count == subscribePacket.subscriptions.count)
-            for index in 0..<subscribePacket.subscriptions.count {
-                #expect(subscribePacket.subscriptions[index].topicFilter == subscribeInfos[index].topicFilter)
-                #expect(subscribePacket.subscriptions[index].qos == subscribeInfos[index].qos)
-            }
-            // send SUBACK
-            let suback = MQTTSubAckPacket(
-                type: .SUBACK,
-                packetId: subscribePacket.packetId,
-                reasons: subscribeInfos.map { _ in .success },
-                properties: .init()
-            )
-            try await channel.writeInboundPacket(suback, version: .v3_1_1)
-
-            try await serverOperation(channel)
-
-            // receive UNSUBSCRIBE
-            packet = try await channel.waitForOutboundPacket()
-            let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v3_1_1, from: packet)
-            #expect(unsubscribePacket.subscriptions == subscribeInfos.map { $0.topicFilter })
-            // send SUBACK
-            let unsuback = MQTTSubAckPacket(
-                type: .UNSUBACK,
-                packetId: unsubscribePacket.packetId,
-                reasons: subscribeInfos.map { _ in .success },
-                properties: .init()
-            )
-            try await channel.writeInboundPacket(unsuback, version: .v3_1_1)
-        }
-    }
-
-    func testSubscribeV5(
-        subscribeInfos: [MQTTSubscribeInfoV5],
-        cleanSession: Bool = true,
-        identifier: String = UUID().uuidString,
-        logger: Logger,
-        client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
-        server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel, UInt32) async throws -> Void,
-    ) async throws {
-        try await withTestMQTTServer(configuration: .init(versionConfiguration: .v5_0()), logger: logger) { connection in
-            try await connection.v5.subscribe(to: subscribeInfos) { sub in
-                try await clientOperation(sub)
-            }
-        } server: { channel in
-            // receive SUBSCRIBE
-            var packet = try await channel.waitForOutboundPacket()
-            let subscribePacket = try MQTTSubscribePacket.read(version: .v5_0, from: packet)
-            #expect(subscribeInfos.count == subscribePacket.subscriptions.count)
-            for index in 0..<subscribePacket.subscriptions.count {
-                #expect(subscribePacket.subscriptions[index].topicFilter == subscribeInfos[index].topicFilter)
-                #expect(subscribePacket.subscriptions[index].qos == subscribeInfos[index].qos)
-            }
-            let properties = try #require(subscribePacket.properties)
-            let subscriptionId: UInt32 = try #require(
-                {
-                    for property in properties {
-                        if case .subscriptionIdentifier(let id) = property {
-                            return id
-                        }
-                    }
-                    return nil
-                }()
-            )
-            // send SUBACK
-            let suback = MQTTSubAckPacket(
-                type: .SUBACK,
-                packetId: subscribePacket.packetId,
-                reasons: subscribeInfos.map { _ in .success },
-                properties: .init()
-            )
-            try await channel.writeInboundPacket(suback, version: .v5_0)
-
-            try await serverOperation(channel, subscriptionId)
-
-            // receive UNSUBSCRIBE
-            packet = try await channel.waitForOutboundPacket()
-            let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v5_0, from: packet)
-            #expect(unsubscribePacket.subscriptions == subscribeInfos.map { $0.topicFilter })
-            // send SUBACK
-            let unsuback = MQTTSubAckPacket(
-                type: .UNSUBACK,
-                packetId: unsubscribePacket.packetId,
-                reasons: subscribeInfos.map { _ in .success },
-                properties: .init()
-            )
-            try await channel.writeInboundPacket(unsuback, version: .v5_0)
-        }
-    }
-
     @Test
     func testConnectDisconnect() async throws {
         try await withTestMQTTServer(logger: Logger(label: #function).withLogLevel(.trace)) { _ in
@@ -252,7 +86,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testSubscribeAndPublishQoS0() async throws {
-        try await testSubscribe(
+        try await withTestSubscription(
             subscribeInfos: [.init(topicFilter: "testTopic", qos: .atMostOnce)],
             logger: Logger(label: #function).withLogLevel(.trace)
         ) { sub in
@@ -277,7 +111,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testSubscribeAndPublishQoS1() async throws {
-        try await testSubscribe(
+        try await withTestSubscription(
             subscribeInfos: [.init(topicFilter: "testTopic", qos: .atLeastOnce)],
             logger: Logger(label: #function).withLogLevel(.trace)
         ) { sub in
@@ -307,7 +141,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testSubscribeAndPublishQoS2() async throws {
-        try await testSubscribe(
+        try await withTestSubscription(
             subscribeInfos: [.init(topicFilter: "testTopic", qos: .exactlyOnce)],
             logger: Logger(label: #function).withLogLevel(.trace)
         ) { sub in
@@ -345,7 +179,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testSubscribeAndDuplicatePublishQoS2() async throws {
-        try await testSubscribe(
+        try await withTestSubscription(
             subscribeInfos: [.init(topicFilter: "testTopic", qos: .exactlyOnce)],
             logger: Logger(label: #function).withLogLevel(.trace)
         ) { sub in
@@ -401,7 +235,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testTopicFilter() async throws {
-        try await testSubscribe(
+        try await withTestSubscription(
             subscribeInfos: [.init(topicFilter: "testTopic/+", qos: .atMostOnce)],
             logger: Logger(label: #function).withLogLevel(.trace)
         ) { sub in
@@ -439,7 +273,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testSubscriptionIdFilter() async throws {
-        try await testSubscribeV5(
+        try await withTestV5Subscription(
             subscribeInfos: [.init(topicFilter: "testTopic/+", qos: .atMostOnce)],
             logger: Logger(label: #function).withLogLevel(.trace)
         ) { sub in

--- a/Tests/MQTTNIOTests/MQTTSubscriptionsTests.swift
+++ b/Tests/MQTTNIOTests/MQTTSubscriptionsTests.swift
@@ -92,11 +92,3 @@ struct MQTTSubscriptionsTests {
         }
     }
 }
-
-extension Logger {
-    func withLogLevel(_ logLevel: Logger.Level) -> Logger {
-        var logger = self
-        logger.logLevel = logLevel
-        return logger
-    }
-}

--- a/Tests/MQTTNIOTests/Utils/Logger+withLogLevel.swift
+++ b/Tests/MQTTNIOTests/Utils/Logger+withLogLevel.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the MQTTNIO project
+//
+// Copyright (c) 2020-2026 Adam Fowler
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+
+extension Logger {
+    func withLogLevel(_ logLevel: Logger.Level) -> Logger {
+        var logger = self
+        logger.logLevel = logLevel
+        return logger
+    }
+}

--- a/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
+++ b/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the MQTTNIO project
+//
+// Copyright (c) 2020-2026 Adam Fowler
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
 import Logging
 import NIOCore
 import NIOEmbedded
@@ -6,6 +20,208 @@ import Testing
 @testable import MQTTNIO
 
 extension MQTTConnectionTests {
+    /// Helper function to test an ``MQTTConnection`` with a test MQTT server using `NIOAsyncTestingChannel`.
+    ///
+    /// This function sets up a test MQTT server and establishes a connection using the provided configuration and session.
+    /// It then performs the specified client and server operations concurrently, allowing for testing of various MQTT interactions.
+    ///
+    /// - Parameters:
+    ///   - configuration: The configuration to use for the MQTT connection.
+    ///   - session: The MQTT session to use for the connection.
+    ///   - logger: The logger to use for logging MQTT events.
+    ///   - connackProperties: The properties to include in the CONNACK packet.
+    ///   - clientOperation: An async operation to perform for the client side of the test.
+    ///         The ``MQTTConnection`` will be passed as a parameter to this operation.
+    ///   - serverOperation: An async operation to perform for the server side of the test.
+    ///         The test MQTT server channel will be passed as a parameter to this operation.
+    func withTestMQTTServer(
+        configuration: MQTTConnectionConfiguration = .init(),
+        session: MQTTSession = MQTTSession(clientID: "", logger: Logger(label: "test_session")),
+        logger: Logger,
+        connackProperties: MQTTProperties = .init(),
+        client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
+        server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void,
+    ) async throws {
+        let channel = NIOAsyncTestingChannel()
+        let connection = try await MQTTConnection.setupChannelAndConnect(
+            channel,
+            configuration: configuration,
+            session: session,
+            logger: logger
+        )
+        let version = configuration.version
+        return try await withThrowingTaskGroup { group in
+            group.addTask {
+                do {
+                    _ = try await connection.sendConnect(clientID: session.clientID, cleanSession: session.clientID.isEmpty)
+                    try await withThrowingTaskGroup { group in
+                        group.addTask { try await connection.handleSessionSubscriptionTasks() }
+                        defer { group.cancelAll() }
+                        try await clientOperation(connection)
+                    }
+                    await connection.saveInflightToSession()
+                    connection.close()
+                } catch {
+                    await connection.saveInflightToSession()
+                    connection.close()
+                    throw error
+                }
+            }
+            group.addTask {
+                // Wait for CONNECT
+                let packet = try await channel.waitForOutboundPacket()
+                let connect = try MQTTConnectPacket.read(version: configuration.version, from: packet)
+                #expect(connect.cleanSession == session.clientID.isEmpty)
+                #expect(connect.clientIdentifier == session.clientID)
+                if case .v5_0(var connectProperties, _, _, let authWorkflow) = configuration.versionConfiguration {
+                    if let authWorkflow {
+                        connectProperties.append(.authenticationMethod(authWorkflow.methodName))
+                    }
+                    #expect(connectProperties == connect.properties)
+                }
+
+                let connack = MQTTConnAckPacket(returnCode: 0, acknowledgeFlags: 1, properties: connackProperties)
+                try await channel.writeInboundPacket(connack, version: version)
+
+                try await serverOperation(channel)
+
+                // Wait for DISCONNECT
+                let disconnectPacket = try await channel.waitForOutboundPacket()
+                #expect(disconnectPacket.type == .DISCONNECT)
+                #expect(disconnectPacket.packetId == 0)
+            }
+            try await group.waitForAll()
+        }
+    }
+
+    /// Helper function to create a ``MQTTSubscription`` with a test MQTT server.
+    ///
+    /// - Parameters:
+    ///   - subscribeInfos: An array of ``MQTTSubscribeInfo`` to subscribe to for this subscription.
+    ///   - cleanSession: Whether to use a clean session for the connection.
+    ///   - identifier: The client identifier to use for the connection. If not provided, a random UUID string will be used.
+    ///   - logger: The logger to use for the test MQTT server.
+    ///   - clientOperation: An async operation to perform for the subscription opened via the connection.
+    ///         The opened subscription will be passed as a parameter to this operation.
+    ///   - serverOperation: An async operation to perform for the subscription on the server side.
+    ///         The test MQTT server channel will be passed as a parameter to this operation.
+    func withTestSubscription(
+        subscribeInfos: [MQTTSubscribeInfo],
+        cleanSession: Bool = true,
+        identifier: String = UUID().uuidString,
+        logger: Logger,
+        client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
+        server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void,
+    ) async throws {
+        try await withTestMQTTServer(logger: logger) { connection in
+            try await connection.subscribe(to: subscribeInfos) { sub in
+                try await clientOperation(sub)
+            }
+        } server: { channel in
+            // Receive SUBSCRIBE
+            var packet = try await channel.waitForOutboundPacket()
+            let subscribePacket = try MQTTSubscribePacket.read(version: .v3_1_1, from: packet)
+            #expect(subscribeInfos.count == subscribePacket.subscriptions.count)
+            for index in 0..<subscribePacket.subscriptions.count {
+                #expect(subscribePacket.subscriptions[index].topicFilter == subscribeInfos[index].topicFilter)
+                #expect(subscribePacket.subscriptions[index].qos == subscribeInfos[index].qos)
+            }
+            // Send SUBACK
+            let suback = MQTTSubAckPacket(
+                type: .SUBACK,
+                packetId: subscribePacket.packetId,
+                reasons: subscribeInfos.map { _ in .success },
+                properties: .init()
+            )
+            try await channel.writeInboundPacket(suback, version: .v3_1_1)
+
+            try await serverOperation(channel)
+
+            // Receive UNSUBSCRIBE
+            packet = try await channel.waitForOutboundPacket()
+            let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v3_1_1, from: packet)
+            #expect(unsubscribePacket.subscriptions == subscribeInfos.map { $0.topicFilter })
+            // Send UNSUBACK
+            let unsuback = MQTTSubAckPacket(
+                type: .UNSUBACK,
+                packetId: unsubscribePacket.packetId,
+                reasons: subscribeInfos.map { _ in .success },
+                properties: .init()
+            )
+            try await channel.writeInboundPacket(unsuback, version: .v3_1_1)
+        }
+    }
+
+    /// Helper function to create a ``MQTTSubscription`` with a test MQTT server using MQTT v5.
+    ///
+    /// - Parameters:
+    ///   - subscribeInfos: An array of ``MQTTSubscribeInfoV5`` to subscribe to for this subscription.
+    ///   - cleanSession: Whether to use a clean session for the connection.
+    ///   - identifier: The client identifier to use for the connection. If not provided, a random UUID string will be used.
+    ///   - logger: The logger to use for the test MQTT server.
+    ///   - clientOperation: An async operation to perform for the subscription opened via the connection.
+    ///         The opened subscription will be passed as a parameter to this operation.
+    ///   - serverOperation: An async operation to perform for the subscription on the server side.
+    ///         The test MQTT server channel will be passed as a parameter to this operation.
+    ///         The subscription identifier will also be passed as a parameter.
+    func withTestV5Subscription(
+        subscribeInfos: [MQTTSubscribeInfoV5],
+        cleanSession: Bool = true,
+        identifier: String = UUID().uuidString,
+        logger: Logger,
+        client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
+        server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel, UInt32) async throws -> Void,
+    ) async throws {
+        try await withTestMQTTServer(configuration: .init(versionConfiguration: .v5_0()), logger: logger) { connection in
+            try await connection.v5.subscribe(to: subscribeInfos) { sub in
+                try await clientOperation(sub)
+            }
+        } server: { channel in
+            // Receive SUBSCRIBE
+            var packet = try await channel.waitForOutboundPacket()
+            let subscribePacket = try MQTTSubscribePacket.read(version: .v5_0, from: packet)
+            #expect(subscribeInfos.count == subscribePacket.subscriptions.count)
+            for index in 0..<subscribePacket.subscriptions.count {
+                #expect(subscribePacket.subscriptions[index].topicFilter == subscribeInfos[index].topicFilter)
+                #expect(subscribePacket.subscriptions[index].qos == subscribeInfos[index].qos)
+            }
+            let properties = try #require(subscribePacket.properties)
+            let subscriptionId: UInt32 = try #require(
+                {
+                    for property in properties {
+                        if case .subscriptionIdentifier(let id) = property {
+                            return id
+                        }
+                    }
+                    return nil
+                }()
+            )
+            // Send SUBACK
+            let suback = MQTTSubAckPacket(
+                type: .SUBACK,
+                packetId: subscribePacket.packetId,
+                reasons: subscribeInfos.map { _ in .success },
+                properties: .init()
+            )
+            try await channel.writeInboundPacket(suback, version: .v5_0)
+
+            try await serverOperation(channel, subscriptionId)
+
+            // Receive UNSUBSCRIBE
+            packet = try await channel.waitForOutboundPacket()
+            let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v5_0, from: packet)
+            #expect(unsubscribePacket.subscriptions == subscribeInfos.map { $0.topicFilter })
+            // Send UNSUBACK
+            let unsuback = MQTTSubAckPacket(
+                type: .UNSUBACK,
+                packetId: unsubscribePacket.packetId,
+                reasons: subscribeInfos.map { _ in .success },
+                properties: .init()
+            )
+            try await channel.writeInboundPacket(unsuback, version: .v5_0)
+        }
+    }
+
     /// Helper function to test multiple ``MQTTSession`` subscriptions with a test MQTT server.
     ///
     /// For each array of ``MQTTSubscribeInfoV5``, a session subscription will be created

--- a/Tests/MQTTNIOTests/Utils/MQTTError+Equatable.swift
+++ b/Tests/MQTTNIOTests/Utils/MQTTError+Equatable.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the MQTTNIO project
+//
+// Copyright (c) 2020-2026 Adam Fowler
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable public import MQTTNIO
+
+extension MQTTError: Equatable {
+    public static func == (lhs: MQTTError, rhs: MQTTError) -> Bool {
+        switch (lhs, rhs) {
+        case (.failedToConnect, .failedToConnect),
+            (.connectionClosed, .connectionClosed),
+            (.serverClosedConnection, .serverClosedConnection),
+            (.unexpectedMessage, .unexpectedMessage),
+            (.decodeError, .decodeError),
+            (.websocketUpgradeFailed, .websocketUpgradeFailed),
+            (.timeout, .timeout),
+            (.retrySend, .retrySend),
+            (.wrongTLSConfig, .wrongTLSConfig),
+            (.badResponse, .badResponse),
+            (.unrecognisedPacketType, .unrecognisedPacketType),
+            (.authWorkflowRequired, .authWorkflowRequired),
+            (.cancelledTask, .cancelledTask),
+            (.packetTooLarge, .packetTooLarge),
+            (.alreadyConnectedWithSession, .alreadyConnectedWithSession),
+            (.noSessionPresent, .noSessionPresent):
+            true
+        case (.connectionError(let lhsValue), .connectionError(let rhsValue)):
+            lhsValue == rhsValue
+        case (.reasonError(let lhsValue), .reasonError(let rhsValue)):
+            lhsValue == rhsValue
+        case (.serverDisconnection(let lhsValue), .serverDisconnection(let rhsValue)):
+            lhsValue.reason == rhsValue.reason && lhsValue.properties == rhsValue.properties
+        case (.versionMismatch(let expectedLHS, let actualLHS), .versionMismatch(let expectedRHS, let actualRHS)):
+            expectedLHS == expectedRHS && actualLHS == actualRHS
+        case (.invalidTopicFilter(let lhsValue), .invalidTopicFilter(let rhsValue)):
+            lhsValue == rhsValue
+        default:
+            false
+        }
+    }
+}


### PR DESCRIPTION
- Move `with`-style testing helpers from MQTTConnectionTests.swift to a separate file
- Move `MQTTError`'s `Equatable` conformance and `Logger` testing extensions to separate files