### PR TITLE
Session storage

### DIFF
--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
@@ -30,7 +30,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
     private let eventLoop: any EventLoop
     @usableFromInline
     var stateMachine: StateMachine<ChannelHandlerContext>
-    let session: MQTTSession
+    var session: MQTTSessionStorage
 
     private var decoder: NIOSingleStepByteToMessageProcessor<ByteToMQTTMessageDecoder>
     private let logger: Logger
@@ -46,7 +46,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
     init(
         configuration: Configuration,
         eventLoop: any EventLoop,
-        session: MQTTSession,
+        session: MQTTSessionStorage,
         logger: Logger
     ) {
         self.configuration = configuration
@@ -188,7 +188,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
         struct DuplicatePublishError: Error {}
         switch message.publish.qos {
         case .atMostOnce:
-            self.session.subscriptions.withLock { $0.notify(message.publish) }
+            self.session.subscriptions.notify(message.publish)
 
         case .atLeastOnce:
             context.channel.writeAndFlush(MQTTPubAckPacket(type: .PUBACK, packetId: message.packetId))
@@ -197,7 +197,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                 .whenComplete { result in
                     switch result {
                     case .success(let publish):
-                        self.session.subscriptions.withLock { $0.notify(publish) }
+                        self.session.subscriptions.notify(publish)
                     case .failure(let error):
                         self.failTasksAndCloseSubscriptions(with: error)
                         context.fireErrorCaught(error)
@@ -239,7 +239,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                         self.logger.error("Error during QoS 2 publish flow", metadata: ["mqtt_error": .string("\(error)")])
                     }
                 case .success:
-                    self.session.subscriptions.withLock { $0.notify(message.publish) }
+                    self.session.subscriptions.notify(message.publish)
                 }
             }
         }
@@ -273,14 +273,13 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
 
         let subscribeAction: MQTTSubscriptions.SubscribeAction
         do {
-            subscribeAction = try self.session.subscriptions.withLock { subscriptions in
-                try subscriptions.addSubscription(
-                    id: id,
-                    continuation: streamContinuation,
-                    subscriptions: packet.subscriptions,
-                    version: self.configuration.version
-                )
-            }
+            subscribeAction = try self.session.subscriptions.addSubscription(
+                id: id,
+                continuation: streamContinuation,
+                subscriptions: packet.subscriptions,
+                version: self.configuration.version
+            )
+
         } catch {
             promise.fail(error)
             return
@@ -311,7 +310,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                 case .success:
                     promise.succeed(subscriptionID)
                 case .failure(let error):
-                    self.session.subscriptions.withLock { $0.removeSubscription(id: subscriptionID) }
+                    self.session.subscriptions.removeSubscription(id: subscriptionID)
                     promise.fail(error)
                 }
             }
@@ -328,7 +327,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
         requestID: Int
     ) {
         self.eventLoop.assertInEventLoop()
-        switch self.session.subscriptions.withLock({ $0.unsubscribe(id: id) }) {
+        switch self.session.subscriptions.unsubscribe(id: id) {
         case .unsubscribe(let subscriptions):
             let packet = MQTTUnsubscribePacket(subscriptions: subscriptions, properties: properties, packetId: packetID)
             guard !packet.subscriptions.isEmpty else {
@@ -438,7 +437,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
             for task in tasks {
                 task.fail(error)
             }
-            self.session.subscriptions.withLock { $0.close(error: error) }
+            self.session.subscriptions.close(error: error)
         case .doNothing:
             break
         }

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -45,15 +45,9 @@ public final actor MQTTConnection: Sendable {
     let channelHandler: MQTTChannelHandler
     let configuration: MQTTConnectionConfiguration
     let globalPacketId = Atomic<UInt16>(1)
-    /// Local copy of inflight messages
-    /*private var inflight: MQTTInflight {
-        get { self.channelHandler.sessionStorage.inflightPackets }
-        set { self.channelHandler.sessionStorage.inflightPackets = newValue }
-    }*/
     let isClosed: Atomic<Bool>
 
     var connectionParameters = ConnectionParameters()
-    //let session: MQTTSession
 
     /// Initialize connection
     private init(

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -100,22 +100,23 @@ public final actor MQTTConnection: Sendable {
         )
         do {
             let value = try await operation(connection, sessionPresent)
-            await connection.closeAndCleanup(session: nil)
+            await connection.closeAndCleanup()
             return value
         } catch {
-            await connection.closeAndCleanup(session: nil)
+            await connection.closeAndCleanup()
             throw error
         }
     }
 
-    package func closeAndCleanup(session: MQTTSession?) async {
+    @discardableResult package func closeAndCleanup() async -> MQTTSessionStorage {
         self.close()
-        session?.storage.put(self.channelHandler.session)
+        let sessionStorage = self.channelHandler.session
         do {
             try await self.channel.closeFuture.get()
         } catch {
             logger.error("Failed to close connection", metadata: ["error": "\(error)"])
         }
+        return sessionStorage
     }
 
     /// Connect to MQTT server with a clean session and run operations using the connection and then close it.
@@ -166,36 +167,38 @@ public final actor MQTTConnection: Sendable {
         logger: Logger,
         operation: (MQTTConnection, Bool) async throws -> Value
     ) async throws -> Value {
-        guard let sessionStorage = session.storage.take() else {
-            throw MQTTError.alreadyConnectedWithSession
-        }
-        let connection: MQTTConnection
-        let sessionPresent: Bool
         do {
-            (connection, sessionPresent) = try await self.connect(
-                address: address,
-                session: sessionStorage,
-                identifier: session.clientID,
-                configuration: configuration,
-                eventLoop: eventLoop,
-                logger: logger
-            )
-        } catch {
-            session.storage.put(sessionStorage)
-            throw error
-        }
-        if !sessionPresent { await connection.closeSubscriptions() }
-        do {
-            let result = try await withThrowingTaskGroup { group in
-                group.addTask { try await connection.handleSessionSubscriptionTasks(session: session) }
-                defer { group.cancelAll() }
-                return try await operation(connection, sessionPresent)
+            return try await session.storage.mutatingBorrow { sessionStorage in
+                let connection: MQTTConnection
+                let sessionPresent: Bool
+                do {
+                    (connection, sessionPresent) = try await self.connect(
+                        address: address,
+                        session: sessionStorage,
+                        identifier: sessionStorage.clientID,
+                        configuration: configuration,
+                        eventLoop: eventLoop,
+                        logger: logger
+                    )
+                } catch {
+                    return (sessionStorage, .failure(error))
+                }
+                if !sessionPresent { await connection.closeSubscriptions() }
+                do {
+                    let result: Value = try await withThrowingTaskGroup { group in
+                        group.addTask { try await connection.handleSessionSubscriptionTasks(session: session) }
+                        defer { group.cancelAll() }
+                        return try await operation(connection, sessionPresent)
+                    }
+                    let sessionStorage = await connection.closeAndCleanup()
+                    return (sessionStorage, .success(result))
+                } catch {
+                    let sessionStorage = await connection.closeAndCleanup()
+                    return (sessionStorage, .failure(error))
+                }
             }
-            await connection.closeAndCleanup(session: session)
-            return result
-        } catch {
-            await connection.closeAndCleanup(session: session)
-            throw error
+        } catch UniqueReferenceError.alreadyBorrowed {
+            throw MQTTError.alreadyConnectedWithSession
         }
     }
 
@@ -269,7 +272,16 @@ public final actor MQTTConnection: Sendable {
     ///
     /// If new subscriptions are opened while waiting, this function will also wait for those subscriptions to complete.
     public func waitUntilNoActiveSubscriptions() async {
-        await self.channelHandler.session.waitUntilNoActiveSubscriptions()
+        await withCheckedContinuation { continuation in
+            if self.channelHandler.session.subscriptions.subscriptionIDMap.isEmpty {
+                self.logger.trace("No active subscriptions to wait for")
+                continuation.resume()
+                return
+            }
+            self.logger.trace("Waiting for \(self.channelHandler.session.subscriptions.subscriptionIDMap.count) active subscriptions to complete")
+            self.channelHandler.session.subscriptions.emptySubscriptionsContinuations.append(continuation)
+        }
+        self.logger.trace("All active subscriptions completed")
     }
 
     /// Connect to MQTT server and return the connection and whether there was a previous session present.

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -46,18 +46,20 @@ public final actor MQTTConnection: Sendable {
     let configuration: MQTTConnectionConfiguration
     let globalPacketId = Atomic<UInt16>(1)
     /// Local copy of inflight messages
-    private var inflight: MQTTInflight
+    /*private var inflight: MQTTInflight {
+        get { self.channelHandler.sessionStorage.inflightPackets }
+        set { self.channelHandler.sessionStorage.inflightPackets = newValue }
+    }*/
     let isClosed: Atomic<Bool>
 
     var connectionParameters = ConnectionParameters()
-    let session: MQTTSession
+    //let session: MQTTSession
 
     /// Initialize connection
     private init(
         channel: any Channel,
         channelHandler: MQTTChannelHandler,
         configuration: MQTTConnectionConfiguration,
-        session: MQTTSession,
         address: MQTTServerAddress?,
         logger: Logger
     ) {
@@ -65,9 +67,7 @@ public final actor MQTTConnection: Sendable {
         self.channel = channel
         self.channelHandler = channelHandler
         self.configuration = configuration
-        self.session = session
         self.logger = logger
-        self.inflight = session.inflightPackets.withLock { $0 }
         self.isClosed = .init(false)
     }
 
@@ -100,16 +100,17 @@ public final actor MQTTConnection: Sendable {
         )
         do {
             let value = try await operation(connection, sessionPresent)
-            await connection.closeAndCleanup()
+            await connection.closeAndCleanup(session: nil)
             return value
         } catch {
-            await connection.closeAndCleanup()
+            await connection.closeAndCleanup(session: nil)
             throw error
         }
     }
 
-    private func closeAndCleanup() async {
+    package func closeAndCleanup(session: MQTTSession?) async {
         self.close()
+        session?.storage.put(self.channelHandler.session)
         do {
             try await self.channel.closeFuture.get()
         } catch {
@@ -165,29 +166,41 @@ public final actor MQTTConnection: Sendable {
         logger: Logger,
         operation: (MQTTConnection, Bool) async throws -> Value
     ) async throws -> Value {
-        let (connection, sessionPresent) = try await self.connect(
-            address: address,
-            session: session,
-            identifier: session.clientID,
-            configuration: configuration,
-            eventLoop: eventLoop,
-            logger: logger
-        )
-        if !sessionPresent { session.subscriptions.withLock { $0.close(error: MQTTError.noSessionPresent) } }
+        guard let sessionStorage = session.storage.take() else {
+            throw MQTTError.alreadyConnectedWithSession
+        }
+        let connection: MQTTConnection
+        let sessionPresent: Bool
+        do {
+            (connection, sessionPresent) = try await self.connect(
+                address: address,
+                session: sessionStorage,
+                identifier: session.clientID,
+                configuration: configuration,
+                eventLoop: eventLoop,
+                logger: logger
+            )
+        } catch {
+            session.storage.put(sessionStorage)
+            throw error
+        }
+        if !sessionPresent { await connection.closeSubscriptions() }
         do {
             let result = try await withThrowingTaskGroup { group in
-                group.addTask { try await connection.handleSessionSubscriptionTasks() }
+                group.addTask { try await connection.handleSessionSubscriptionTasks(session: session) }
                 defer { group.cancelAll() }
                 return try await operation(connection, sessionPresent)
             }
-            await connection.saveInflightToSession()
-            await connection.closeAndCleanup()
+            await connection.closeAndCleanup(session: session)
             return result
         } catch {
-            await connection.saveInflightToSession()
-            await connection.closeAndCleanup()
+            await connection.closeAndCleanup(session: session)
             throw error
         }
+    }
+
+    func closeSubscriptions() {
+        self.channelHandler.session.subscriptions.close(error: MQTTError.noSessionPresent)
     }
 
     /// Connect to MQTT server and run operations using the connection and then close it.
@@ -256,7 +269,7 @@ public final actor MQTTConnection: Sendable {
     ///
     /// If new subscriptions are opened while waiting, this function will also wait for those subscriptions to complete.
     public func waitUntilNoActiveSubscriptions() async {
-        await self.session.waitUntilNoActiveSubscriptions()
+        await self.channelHandler.session.waitUntilNoActiveSubscriptions()
     }
 
     /// Connect to MQTT server and return the connection and whether there was a previous session present.
@@ -272,13 +285,13 @@ public final actor MQTTConnection: Sendable {
     /// - Returns: Tuple of the ``MQTTConnection`` and a `Bool` indicating if there was a previous session present.
     private static func connect(
         address: MQTTServerAddress,
-        session: MQTTSession?,
+        session: MQTTSessionStorage?,
         identifier: String,
         configuration: MQTTConnectionConfiguration,
         eventLoop: any EventLoop = MultiThreadedEventLoopGroup.singleton.any(),
         logger: Logger
     ) async throws -> (MQTTConnection, Bool) {
-        let _session = session ?? MQTTSession(clientID: identifier, logger: logger)
+        let _session = session ?? MQTTSessionStorage(clientID: identifier, logger: logger)
         let future =
             if eventLoop.inEventLoop {
                 self._makeConnection(
@@ -364,22 +377,16 @@ public final actor MQTTConnection: Sendable {
             properties: properties,
             will: publish
         )
-        guard
+        /*guard
             self.session.isConnected.compareExchange(expected: false, desired: true, successOrdering: .relaxed, failureOrdering: .relaxed).exchanged
         else {
             throw MQTTError.alreadyConnectedWithSession
-        }
+        }*/
         return try await self._connect(packet: packet, authWorkflow: authenticator).sessionPresent
     }
 
-    /// Copy the local copy of inflight messages back to the session.
-    func saveInflightToSession() {
-        self.session.inflightPackets.withLock { $0 = inflight }
-        self.session.isConnected.store(false, ordering: .relaxed)
-    }
-
     /// Iterates over subscription tasks in the session queue and handles them.
-    func handleSessionSubscriptionTasks() async throws {
+    func handleSessionSubscriptionTasks(session: MQTTSession) async throws {
         for await task in session.subscriptionsQueue {
             switch task {
             case .subscribe(let queuedSubscription):
@@ -438,7 +445,7 @@ public final actor MQTTConnection: Sendable {
     private static func _makeConnection(
         address: MQTTServerAddress,
         configuration: MQTTConnectionConfiguration,
-        session: MQTTSession,
+        session: MQTTSessionStorage,
         eventLoop: any EventLoop,
         logger: Logger
     ) -> EventLoopFuture<MQTTConnection> {
@@ -515,7 +522,6 @@ public final actor MQTTConnection: Sendable {
                 channel: channel,
                 channelHandler: handler,
                 configuration: configuration,
-                session: session,
                 address: address,
                 logger: logger
             )
@@ -525,7 +531,7 @@ public final actor MQTTConnection: Sendable {
     package static func setupChannelAndConnect(
         _ channel: any Channel,
         configuration: MQTTConnectionConfiguration = .init(),
-        session: MQTTSession,
+        session: MQTTSessionStorage,
         logger: Logger
     ) async throws -> MQTTConnection {
         if !channel.eventLoop.inEventLoop {
@@ -549,7 +555,7 @@ public final actor MQTTConnection: Sendable {
     private static func _setupChannelAndConnect(
         _ channel: any Channel,
         configuration: MQTTConnectionConfiguration,
-        session: MQTTSession,
+        session: MQTTSessionStorage,
         logger: Logger
     ) -> EventLoopFuture<MQTTConnection> {
         do {
@@ -565,7 +571,6 @@ public final actor MQTTConnection: Sendable {
                         channel: channel,
                         channelHandler: handler,
                         configuration: configuration,
-                        session: session,
                         address: .hostname("127.0.0.1", port: 1883),
                         logger: logger
                     )
@@ -580,7 +585,7 @@ public final actor MQTTConnection: Sendable {
     private static func _setupChannel(
         _ channel: any Channel,
         configuration: MQTTConnectionConfiguration,
-        session: MQTTSession,
+        session: MQTTSessionStorage,
         logger: Logger
     ) throws -> MQTTChannelHandler {
         channel.eventLoop.assertInEventLoop()
@@ -735,7 +740,7 @@ public final actor MQTTConnection: Sendable {
             if connack.sessionPresent {
                 try await self.resendOnRestart()
             } else {
-                self.inflight.clear()
+                self.channelHandler.session.inflight.clear()
             }
             let ack = try self.processConnack(connack)
             return ack
@@ -783,8 +788,8 @@ public final actor MQTTConnection: Sendable {
 
     /// Resend PUBLISH and PUBREL messages
     func resendOnRestart() async throws {
-        let inflight = self.inflight.packets
-        self.inflight.clear()
+        let inflight = self.channelHandler.session.inflight.packets
+        self.channelHandler.session.inflight.clear()
         for packet in inflight {
             switch packet {
             case let publish as MQTTPublishPacket:
@@ -832,7 +837,7 @@ public final actor MQTTConnection: Sendable {
             }
             // client identifier
             if case .assignedClientIdentifier(let identifier) = property {
-                self.session.setClientID(identifier)
+                self.channelHandler.session.clientID = identifier
             }
             // max QoS
             if case .maximumQoS(let qos) = property {
@@ -921,12 +926,12 @@ public final actor MQTTConnection: Sendable {
             return nil
         }
 
-        self.inflight.add(packet: packet)
+        self.channelHandler.session.inflight.add(packet: packet)
         let ackPacket: any MQTTPacket
         do {
             ackPacket = try await self.sendMessage(packet) { message in
                 guard message.packetId == packet.packetId else { return false }
-                self.inflight.remove(id: packet.packetId)
+                self.channelHandler.session.inflight.remove(id: packet.packetId)
                 if packet.publish.qos == .atLeastOnce {
                     guard message.type == .PUBACK else {
                         throw MQTTError.unexpectedMessage
@@ -948,7 +953,7 @@ public final actor MQTTConnection: Sendable {
             if case MQTTError.serverDisconnection(let ack) = error,
                 ack.reason == .malformedPacket
             {
-                self.inflight.remove(id: packet.packetId)
+                self.channelHandler.session.inflight.remove(id: packet.packetId)
             }
             throw error
         }
@@ -962,11 +967,11 @@ public final actor MQTTConnection: Sendable {
     }
 
     func pubRel(packet: MQTTPubAckPacket) async throws -> any MQTTPacket {
-        self.inflight.add(packet: packet)
+        self.channelHandler.session.inflight.add(packet: packet)
         return try await self.sendMessage(packet) { message in
             guard message.packetId == packet.packetId else { return false }
             guard message.type != .PUBREC else { return false }
-            self.inflight.remove(id: packet.packetId)
+            self.channelHandler.session.inflight.remove(id: packet.packetId)
             guard message.type == .PUBCOMP else {
                 throw MQTTError.unexpectedMessage
             }

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -383,11 +383,6 @@ public final actor MQTTConnection: Sendable {
             properties: properties,
             will: publish
         )
-        /*guard
-            self.session.isConnected.compareExchange(expected: false, desired: true, successOrdering: .relaxed, failureOrdering: .relaxed).exchanged
-        else {
-            throw MQTTError.alreadyConnectedWithSession
-        }*/
         return try await self._connect(packet: packet, authWorkflow: authenticator).sessionPresent
     }
 

--- a/Sources/MQTTNIO/Session/MQTTSession.swift
+++ b/Sources/MQTTNIO/Session/MQTTSession.swift
@@ -23,10 +23,7 @@ public final class MQTTSession: Sendable {
     /// Whether a ``MQTTConnection`` is currently connected using this session.
     let isConnected: Atomic<Bool>
 
-    /// Inflight messages
-    let inflightPackets: Mutex<MQTTInflight>
-
-    let subscriptions: Mutex<MQTTSubscriptions>
+    let storage: UniqueReference<MQTTSessionStorage>
 
     let subscriptionsQueue: AsyncStream<SessionSubscriptionTask>
     @usableFromInline
@@ -49,11 +46,10 @@ public final class MQTTSession: Sendable {
     ///   - logger: Logger to use for this session.
     public init(clientID: String, logger: Logger) {
         self._clientID = .init(clientID)
-        self.inflightPackets = .init(.init())
-        self.subscriptions = .init(.init(logger: logger))
         self.isConnected = .init(false)
         (self.subscriptionsQueue, self.subscriptionsQueueContinuation) = AsyncStream.makeStream()
         self.logger = logger
+        self.storage = .init(.init(clientID: clientID, logger: logger))
     }
 }
 
@@ -72,15 +68,6 @@ extension MQTTSession {
 
     func setClientID(_ clientID: String) {
         self._clientID.withLock { $0 = clientID }
-    }
-}
-
-// MARK: - Inflight Messages
-
-extension MQTTSession {
-    /// Used for testing
-    package var inflightPacketsCount: Int {
-        self.inflightPackets.withLock { $0.packets.count }
     }
 }
 
@@ -122,6 +109,19 @@ extension MQTTSession {
         case unsubscribe(QueuedUnsubscription)
     }
 
+}
+
+package struct MQTTSessionStorage: Sendable {
+    var inflight: MQTTInflight
+    var subscriptions: MQTTSubscriptions
+    var clientID: String
+
+    package init(clientID: String, logger: Logger) {
+        self.inflight = .init()
+        self.subscriptions = .init(logger: logger)
+        self.clientID = clientID
+    }
+
     /// Wait until there are no active subscriptions opened via this session or via any ``MQTTConnection``s using this session.
     ///
     /// This function waits only for subscriptions that have been acknowledged by the server,
@@ -130,17 +130,38 @@ extension MQTTSession {
     ///
     /// If new subscriptions are opened while waiting, this function will also wait for those subscriptions to complete.
     public func waitUntilNoActiveSubscriptions() async {
-        await withCheckedContinuation { continuation in
-            self.subscriptions.withLock { subscriptions in
-                if subscriptions.subscriptionIDMap.isEmpty {
-                    self.logger.trace("No active subscriptions to wait for")
-                    continuation.resume()
-                    return
-                }
-                self.logger.trace("Waiting for \(subscriptions.subscriptionIDMap.count) active subscriptions to complete")
-                subscriptions.emptySubscriptionsContinuations.append(continuation)
+        /*await withCheckedContinuation { continuation in
+            if subscriptions.subscriptionIDMap.isEmpty {
+                self.subscriptions.logger.trace("No active subscriptions to wait for")
+                continuation.resume()
+                return
             }
+            self.subscriptions.logger.trace("Waiting for \(subscriptions.subscriptionIDMap.count) active subscriptions to complete")
+            subscriptions.emptySubscriptionsContinuations.append(continuation)
         }
-        self.logger.trace("All active subscriptions completed")
+        self.subscriptions.logger.trace("All active subscriptions completed")*/
+    }
+}
+
+struct UniqueReference<Value: Sendable>: ~Copyable, Sendable {
+    let ref: Mutex<Value?>
+
+    init(_ value: Value) {
+        self.ref = .init(value)
+    }
+
+    func take() -> Value? {
+        self.ref.withLock {
+            let value = $0
+            $0 = nil
+            return value
+        }
+    }
+
+    func put(_ value: Value) {
+        self.ref.withLock {
+            guard $0 == nil else { preconditionFailure("Value already stored") }
+            $0 = value
+        }
     }
 }

--- a/Sources/MQTTNIO/Session/MQTTSession.swift
+++ b/Sources/MQTTNIO/Session/MQTTSession.swift
@@ -18,7 +18,7 @@ import Synchronization
 /// Represents an MQTT session, holding session state such as inflight messages.
 /// Used by ``MQTTConnection`` to manage session state across connections.
 public final class MQTTSession: Sendable {
-    // data associated with session that is borrowed by the connection
+    /// Data associated with session that is borrowed by the connection
     let storage: UniqueReference<MQTTSessionStorage>
 
     let subscriptionsQueue: AsyncStream<SessionSubscriptionTask>

--- a/Sources/MQTTNIO/Session/MQTTSession.swift
+++ b/Sources/MQTTNIO/Session/MQTTSession.swift
@@ -18,11 +18,7 @@ import Synchronization
 /// Represents an MQTT session, holding session state such as inflight messages.
 /// Used by ``MQTTConnection`` to manage session state across connections.
 public final class MQTTSession: Sendable {
-    private let _clientID: Mutex<String>
-
-    /// Whether a ``MQTTConnection`` is currently connected using this session.
-    let isConnected: Atomic<Bool>
-
+    // data associated with session that is borrowed by the connection
     let storage: UniqueReference<MQTTSessionStorage>
 
     let subscriptionsQueue: AsyncStream<SessionSubscriptionTask>
@@ -45,29 +41,9 @@ public final class MQTTSession: Sendable {
     ///   - clientID: Client identifier to use for this session. This must be unique.
     ///   - logger: Logger to use for this session.
     public init(clientID: String, logger: Logger) {
-        self._clientID = .init(clientID)
-        self.isConnected = .init(false)
         (self.subscriptionsQueue, self.subscriptionsQueueContinuation) = AsyncStream.makeStream()
         self.logger = logger
         self.storage = .init(.init(clientID: clientID, logger: logger))
-    }
-}
-
-// MARK: - Client ID
-
-extension MQTTSession {
-    /// Client Identifier for this session.
-    ///
-    /// If you provided an empty string as the Client Identifier when initializing this session,
-    /// the MQTT server should have generated a unique Client Identifier for you on the first connection with this session.
-    /// If that first connection was a MQTT v5 connection,
-    /// this property will contain the assigned Client Identifier.
-    public var clientID: String {
-        self._clientID.withLock { $0 }
-    }
-
-    func setClientID(_ clientID: String) {
-        self._clientID.withLock { $0 = clientID }
     }
 }
 
@@ -109,59 +85,4 @@ extension MQTTSession {
         case unsubscribe(QueuedUnsubscription)
     }
 
-}
-
-package struct MQTTSessionStorage: Sendable {
-    var inflight: MQTTInflight
-    var subscriptions: MQTTSubscriptions
-    var clientID: String
-
-    package init(clientID: String, logger: Logger) {
-        self.inflight = .init()
-        self.subscriptions = .init(logger: logger)
-        self.clientID = clientID
-    }
-
-    /// Wait until there are no active subscriptions opened via this session or via any ``MQTTConnection``s using this session.
-    ///
-    /// This function waits only for subscriptions that have been acknowledged by the server,
-    /// so for example if a subscription is opened via this ``MQTTSession`` but the session is not passed to a ``MQTTConnection``,
-    /// this function will not wait for that subscription.
-    ///
-    /// If new subscriptions are opened while waiting, this function will also wait for those subscriptions to complete.
-    public func waitUntilNoActiveSubscriptions() async {
-        /*await withCheckedContinuation { continuation in
-            if subscriptions.subscriptionIDMap.isEmpty {
-                self.subscriptions.logger.trace("No active subscriptions to wait for")
-                continuation.resume()
-                return
-            }
-            self.subscriptions.logger.trace("Waiting for \(subscriptions.subscriptionIDMap.count) active subscriptions to complete")
-            subscriptions.emptySubscriptionsContinuations.append(continuation)
-        }
-        self.subscriptions.logger.trace("All active subscriptions completed")*/
-    }
-}
-
-struct UniqueReference<Value: Sendable>: ~Copyable, Sendable {
-    let ref: Mutex<Value?>
-
-    init(_ value: Value) {
-        self.ref = .init(value)
-    }
-
-    func take() -> Value? {
-        self.ref.withLock {
-            let value = $0
-            $0 = nil
-            return value
-        }
-    }
-
-    func put(_ value: Value) {
-        self.ref.withLock {
-            guard $0 == nil else { preconditionFailure("Value already stored") }
-            $0 = value
-        }
-    }
 }

--- a/Sources/MQTTNIO/Session/MQTTSessionStorage.swift
+++ b/Sources/MQTTNIO/Session/MQTTSessionStorage.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the MQTTNIO project
+//
+// Copyright (c) 2020-2026 Adam Fowler
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+package import Logging
+import NIOCore
+import Synchronization
+
+/// MQTT session data.
+package struct MQTTSessionStorage: Sendable {
+    var inflight: MQTTInflight
+    var subscriptions: MQTTSubscriptions
+    var clientID: String
+
+    package init(clientID: String, logger: Logger) {
+        self.inflight = .init()
+        self.subscriptions = .init(logger: logger)
+        self.clientID = clientID
+    }
+}

--- a/Sources/MQTTNIO/Subscriptions/MQTTSubscriptions.swift
+++ b/Sources/MQTTNIO/Subscriptions/MQTTSubscriptions.swift
@@ -14,7 +14,7 @@
 import Logging
 import Synchronization
 
-struct MQTTSubscriptions {
+struct MQTTSubscriptions: Sendable {
     var subscriptionIDMap: [UInt32: SubscriptionRef]
     var subscriptionMap: [TopicFilter: MQTTTopicStateMachine<SubscriptionRef>]
     let logger: Logger
@@ -203,7 +203,7 @@ struct MQTTSubscriptions {
 }
 
 /// Individual subscription associated with one subscribe
-final class SubscriptionRef: Identifiable {
+final class SubscriptionRef: Identifiable, Sendable {
     let id: UInt32
     let version: MQTTConnectionConfiguration.Version
     let topicFilters: [TopicFilter]

--- a/Sources/MQTTNIO/Subscriptions/MQTTTopicStateMachine.swift
+++ b/Sources/MQTTNIO/Subscriptions/MQTTTopicStateMachine.swift
@@ -12,9 +12,9 @@
 //===----------------------------------------------------------------------===//
 
 @usableFromInline
-struct MQTTTopicStateMachine<Value: Identifiable> where Value: AnyObject {
+struct MQTTTopicStateMachine<Value: Identifiable & Sendable>: Sendable where Value: AnyObject {
     @usableFromInline
-    enum State {
+    enum State: Sendable {
         case uninitialized
         case active([Value])
         case closed

--- a/Sources/MQTTNIO/Subscriptions/TopicFilter.swift
+++ b/Sources/MQTTNIO/Subscriptions/TopicFilter.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-struct TopicFilter: Hashable {
+struct TopicFilter: Hashable, Sendable {
     enum Level: Equatable {
         case string(Substring)
         case multiLevelWildcard

--- a/Sources/MQTTNIO/Utils/UniqueReference.swift
+++ b/Sources/MQTTNIO/Utils/UniqueReference.swift
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the MQTTNIO project
+//
+// Copyright (c) 2020-2026 Adam Fowler
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Synchronization
+
+enum UniqueReferenceError: Error {
+    case alreadyBorrowed
+}
+
+struct UniqueReference<Value: Sendable>: ~Copyable, Sendable {
+
+    let ref: Mutex<Value?>
+
+    init(_ value: Value) {
+        self.ref = .init(value)
+    }
+
+    /// borrow value and return a mutated version
+    func mutatingBorrow<Return>(_ operation: (Value) async -> (Value, Result<Return, any Error>)) async throws -> Return {
+        guard let value = take() else { throw UniqueReferenceError.alreadyBorrowed }
+        let (newValue, result) = await operation(value)
+        put(newValue)
+        return try result.get()
+    }
+
+    /// borrow value without mutating it
+    func borrow<Return>(_ operation: (Value) throws -> Return) throws -> Return {
+        guard let value = take() else { throw UniqueReferenceError.alreadyBorrowed }
+        do {
+            let result = try operation(value)
+            put(value)
+            return result
+        } catch {
+            put(value)
+            throw error
+        }
+    }
+
+    private func take() -> Value? {
+        self.ref.withLock {
+            let value = $0
+            $0 = nil
+            return value
+        }
+    }
+
+    private func put(_ value: Value) {
+        self.ref.withLock {
+            guard $0 == nil else { preconditionFailure("Value already stored") }
+            $0 = value
+        }
+    }
+}

--- a/Sources/MQTTNIO/Utils/UniqueReference.swift
+++ b/Sources/MQTTNIO/Utils/UniqueReference.swift
@@ -18,7 +18,6 @@ enum UniqueReferenceError: Error {
 }
 
 struct UniqueReference<Value: Sendable>: ~Copyable, Sendable {
-
     let ref: Mutex<Value?>
 
     init(_ value: Value) {

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -676,8 +676,7 @@ struct IntegrationTests {
                     connection.close()
                 }
 
-                //TODO: get inflight count
-                //#expect(session.inflightPacketsCount > 0)
+                #expect(try session.storage.borrow { $0.inflight.packets.count } > 0)
 
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
@@ -687,8 +686,7 @@ struct IntegrationTests {
                     try await connection.ping()
                 }
 
-                //TODO: get inflight count
-                //#expect(session.inflightPacketsCount == 0)
+                #expect(try session.storage.borrow { $0.inflight.packets.count } == 0)
             }
 
             try await group.waitForAll()
@@ -1027,7 +1025,8 @@ struct IntegrationTests {
                 // Wait for the subscription to be setup
                 await stream.first { _ in true }
 
-                // Check that the subscription is registered in the session
+                // Check that the subscription is registered in the session, cannot check this from the
+                // session as the storage is borrowed by the connection
                 /*TODO: check subscriptions
                 session.subscriptions.withLock {
                     #expect($0.subscriptionIDMap.count == 1)
@@ -1042,14 +1041,9 @@ struct IntegrationTests {
                 await #expect(throws: MQTTError.self) {
                     try await group.next()
                 }
-
-                // Check that the subscription has been removed from the session after the connection is closed
-                /*TODO: check subscriptions
-                session.subscriptions.withLock {
-                    #expect($0.subscriptionIDMap.isEmpty)
-                }*/
             }
         }
+        #expect(try session.storage.borrow { $0.subscriptions.subscriptionIDMap.isEmpty })
     }
 
     @Test("Wait Until No Active Subscriptions")

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -1025,12 +1025,7 @@ struct IntegrationTests {
                 // Wait for the subscription to be setup
                 await stream.first { _ in true }
 
-                // Check that the subscription is registered in the session, cannot check this from the
-                // session as the storage is borrowed by the connection
-                /*TODO: check subscriptions
-                session.subscriptions.withLock {
-                    #expect($0.subscriptionIDMap.count == 1)
-                }*/
+                await #expect(connection.session.subscriptions.subscriptionIDMap.count == 1)
 
                 if clientClose {
                     connection.close()
@@ -1145,4 +1140,9 @@ struct IntegrationTests {
             throw InternalError.notImplemented
         }
     }
+}
+
+extension MQTTConnection {
+    /// Test helper to get session
+    var session: MQTTSessionStorage { self.channelHandler.session }
 }

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -676,7 +676,8 @@ struct IntegrationTests {
                     connection.close()
                 }
 
-                #expect(session.inflightPacketsCount > 0)
+                //TODO: get inflight count
+                //#expect(session.inflightPacketsCount > 0)
 
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
@@ -686,7 +687,8 @@ struct IntegrationTests {
                     try await connection.ping()
                 }
 
-                #expect(session.inflightPacketsCount == 0)
+                //TODO: get inflight count
+                //#expect(session.inflightPacketsCount == 0)
             }
 
             try await group.waitForAll()
@@ -1026,9 +1028,10 @@ struct IntegrationTests {
                 await stream.first { _ in true }
 
                 // Check that the subscription is registered in the session
+                /*TODO: check subscriptions
                 session.subscriptions.withLock {
                     #expect($0.subscriptionIDMap.count == 1)
-                }
+                }*/
 
                 if clientClose {
                     connection.close()
@@ -1041,9 +1044,10 @@ struct IntegrationTests {
                 }
 
                 // Check that the subscription has been removed from the session after the connection is closed
+                /*TODO: check subscriptions
                 session.subscriptions.withLock {
                     #expect($0.subscriptionIDMap.isEmpty)
-                }
+                }*/
             }
         }
     }

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -92,8 +92,8 @@ struct IntegrationV5Tests {
             session: session,
             logger: Logger(label: #function).withLogLevel(.trace)
         ) { connection in
-            #expect(!session.clientID.isEmpty)
         }
+        #expect(try !session.storage.borrow { $0.clientID }.isEmpty)
     }
 
     @Test("Publish", arguments: MQTTQoS.allCases, [MQTTProperties.Property.contentType("text/plain"), nil])

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -388,7 +388,7 @@ struct MQTTConnectionTests {
         let connection = try await MQTTConnection.setupChannelAndConnect(
             channel,
             configuration: .init(versionConfiguration: .v5_0(authWorkflow: SimpleAuthWorkflow())),
-            session: MQTTSession(clientID: "", logger: Logger(label: #function).withLogLevel(.trace)),
+            session: MQTTSessionStorage(clientID: "", logger: Logger(label: #function).withLogLevel(.trace)),
             logger: Logger(label: #function).withLogLevel(.trace)
         )
         return try await withThrowingTaskGroup { group in
@@ -512,7 +512,8 @@ struct MQTTConnectionTests {
             cont.yield()
         }
 
-        #expect(session.inflightPacketsCount > 0)
+        //TODO: Fix accessing packet count
+        //#expect(session.inflightPacketsCount > 0)
 
         try await withTestMQTTServer(session: session, logger: logger) { _ in
             await stream.first { _ in true }
@@ -533,7 +534,8 @@ struct MQTTConnectionTests {
             cont.yield()
         }
 
-        #expect(session.inflightPacketsCount == 0)
+        //TODO: Fix accessing packet count
+        //#expect(session.inflightPacketsCount == 0)
     }
 
     @Test("Maximum Packet Size", arguments: MQTTQoS.allCases)

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -512,8 +512,7 @@ struct MQTTConnectionTests {
             cont.yield()
         }
 
-        //TODO: Fix accessing packet count
-        //#expect(session.inflightPacketsCount > 0)
+        #expect(try session.storage.borrow { $0.inflight.packets.count > 0 })
 
         try await withTestMQTTServer(session: session, logger: logger) { _ in
             await stream.first { _ in true }
@@ -534,8 +533,7 @@ struct MQTTConnectionTests {
             cont.yield()
         }
 
-        //TODO: Fix accessing packet count
-        //#expect(session.inflightPacketsCount == 0)
+        #expect(try session.storage.borrow { $0.inflight.packets.count == 0 })
     }
 
     @Test("Maximum Packet Size", arguments: MQTTQoS.allCases)

--- a/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
+++ b/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
@@ -43,54 +43,67 @@ extension MQTTConnectionTests {
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void,
     ) async throws {
         let channel = NIOAsyncTestingChannel()
-        let connection = try await MQTTConnection.setupChannelAndConnect(
-            channel,
-            configuration: configuration,
-            session: session,
-            logger: logger
-        )
-        let version = configuration.version
-        return try await withThrowingTaskGroup { group in
-            group.addTask {
+        do {
+            try await session.storage.mutatingBorrow { sessionStorage -> (MQTTSessionStorage, Result<Void, any Error>) in
+                let connection: MQTTConnection
                 do {
-                    _ = try await connection.sendConnect(clientID: session.clientID, cleanSession: session.clientID.isEmpty)
-                    try await withThrowingTaskGroup { group in
-                        group.addTask { try await connection.handleSessionSubscriptionTasks() }
-                        defer { group.cancelAll() }
-                        try await clientOperation(connection)
-                    }
-                    await connection.saveInflightToSession()
-                    connection.close()
+                    connection = try await MQTTConnection.setupChannelAndConnect(
+                        channel,
+                        configuration: configuration,
+                        session: sessionStorage,
+                        logger: logger
+                    )
                 } catch {
-                    await connection.saveInflightToSession()
-                    connection.close()
-                    throw error
+                    return (sessionStorage, .failure(error))
                 }
-            }
-            group.addTask {
-                // Wait for CONNECT
-                let packet = try await channel.waitForOutboundPacket()
-                let connect = try MQTTConnectPacket.read(version: configuration.version, from: packet)
-                #expect(connect.cleanSession == session.clientID.isEmpty)
-                #expect(connect.clientIdentifier == session.clientID)
-                if case .v5_0(var connectProperties, _, _, let authWorkflow) = configuration.versionConfiguration {
-                    if let authWorkflow {
-                        connectProperties.append(.authenticationMethod(authWorkflow.methodName))
+                let version = configuration.version
+                return await withTaskGroup(of: (MQTTSessionStorage, Result<Void, any Error>).self) { group in
+                    group.addTask {
+                        do {
+                            _ = try await connection.sendConnect(clientID: sessionStorage.clientID, cleanSession: sessionStorage.clientID.isEmpty)
+                            try await withThrowingTaskGroup { group in
+                                group.addTask { try await connection.handleSessionSubscriptionTasks(session: session) }
+                                defer { group.cancelAll() }
+                                try await clientOperation(connection)
+                            }
+                            let sessionStorage = await connection.closeAndCleanup()
+                            return (sessionStorage, .success(()))
+                        } catch {
+                            let sessionStorage = await connection.closeAndCleanup()
+                            return (sessionStorage, .failure(error))
+                        }
                     }
-                    #expect(connectProperties == connect.properties)
+                    do {
+                        // wait for connect
+                        let packet = try await channel.waitForOutboundPacket()
+                        let connect = try MQTTConnectPacket.read(version: configuration.version, from: packet)
+                        #expect(connect.cleanSession == sessionStorage.clientID.isEmpty)
+                        #expect(connect.clientIdentifier == sessionStorage.clientID)
+                        if case .v5_0(var connectProperties, _, _, let authWorkflow) = configuration.versionConfiguration {
+                            if let authWorkflow {
+                                connectProperties.append(.authenticationMethod(authWorkflow.methodName))
+                            }
+                            #expect(connectProperties == connect.properties)
+                        }
+
+                        let connack = MQTTConnAckPacket(returnCode: 0, acknowledgeFlags: 1, properties: connackProperties)
+                        try await channel.writeInboundPacket(connack, version: version)
+
+                        try await serverOperation(channel)
+
+                        // wait for disconnect
+                        let disconnectPacket = try await channel.waitForOutboundPacket()
+                        #expect(disconnectPacket.type == .DISCONNECT)
+                        #expect(disconnectPacket.packetId == 0)
+                    } catch {
+                        return (sessionStorage, .failure(error))
+                    }
+
+                    return await group.next()!
                 }
-
-                let connack = MQTTConnAckPacket(returnCode: 0, acknowledgeFlags: 1, properties: connackProperties)
-                try await channel.writeInboundPacket(connack, version: version)
-
-                try await serverOperation(channel)
-
-                // Wait for DISCONNECT
-                let disconnectPacket = try await channel.waitForOutboundPacket()
-                #expect(disconnectPacket.type == .DISCONNECT)
-                #expect(disconnectPacket.packetId == 0)
             }
-            try await group.waitForAll()
+        } catch UniqueReferenceError.alreadyBorrowed {
+            throw MQTTError.alreadyConnectedWithSession
         }
     }
 


### PR DESCRIPTION
Separate subscription state, inflight packets and client ID from session and store in separate type `MQTTSessionStorage`. Which is stored inside a `UniqueReference` in the MQTTSession. When a connection is created that is serving the session it borrows the session storage and stores it in the channel handler until the connection closes. On close it will update the session storage in the MQTTSession with the state from the channel handler.

If another connection attempts to borrow the session state while it is already borrowed it will throw an error saying this session is already being served by a connection.

This change does mean it is not possible to access various session parameters from `MQTTSession`.