### PR TITLE
Add waitOnClose, clean up withConnection calls

### DIFF
--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -74,7 +74,7 @@ public final actor MQTTConnection: Sendable {
     ///   - eventLoop: EventLoop to run the connection on.
     ///   - logger: Logger to use for the connection.
     ///   - operation: Closure handling the MQTT connection.
-    ///     The closure receives the ``MQTTConnection`` and a `Bool` indicating if there was a previous session present.
+    ///     The closure receives the ``MQTTConnection``
     /// - Returns: Value returned from the operation closure.
     public static func withConnection<Value>(
         address: MQTTServerAddress,
@@ -82,9 +82,9 @@ public final actor MQTTConnection: Sendable {
         identifier: String = "",
         eventLoop: any EventLoop = MultiThreadedEventLoopGroup.singleton.any(),
         logger: Logger,
-        operation: (MQTTConnection, Bool) async throws -> Value
+        operation: (MQTTConnection) async throws -> Value
     ) async throws -> Value {
-        let (connection, sessionPresent) = try await self.connect(
+        let (connection, _) = try await self.connect(
             address: address,
             session: nil,
             identifier: identifier,
@@ -93,7 +93,7 @@ public final actor MQTTConnection: Sendable {
             logger: logger
         )
         do {
-            let value = try await operation(connection, sessionPresent)
+            let value = try await operation(connection)
             await connection.closeAndCleanup()
             return value
         } catch {
@@ -113,32 +113,12 @@ public final actor MQTTConnection: Sendable {
         return sessionStorage
     }
 
-    /// Connect to MQTT server with a clean session and run operations using the connection and then close it.
-    ///
-    /// - Parameters:
-    ///   - address: Internet address of the MQTT server.
-    ///   - configuration: Configuration of the MQTT connection.
-    ///   - identifier: Client identifier for the server. This must be unique.
-    ///   - eventLoop: EventLoop to run the connection on.
-    ///   - logger: Logger to use for the connection.
-    ///   - operation: Closure handling the MQTT connection.
-    /// - Returns: Value returned from the operation closure.
-    public static func withConnection<Value>(
-        address: MQTTServerAddress,
-        configuration: MQTTConnectionConfiguration = .init(),
-        identifier: String = "",
-        eventLoop: any EventLoop = MultiThreadedEventLoopGroup.singleton.any(),
-        logger: Logger,
-        operation: (MQTTConnection) async throws -> Value
-    ) async throws -> Value {
-        try await Self.withConnection(
-            address: address,
-            configuration: configuration,
-            identifier: identifier,
-            eventLoop: eventLoop,
-            logger: logger
-        ) { connection, _ in
-            try await operation(connection)
+    ///  Wait on connection closing
+    public func waitOnClose() async {
+        do {
+            try await self.channel.closeFuture.get()
+        } catch {
+            logger.error("Failed to close connection", metadata: ["error": "\(error)"])
         }
     }
 
@@ -198,35 +178,6 @@ public final actor MQTTConnection: Sendable {
 
     func closeSubscriptions() {
         self.channelHandler.session.subscriptions.close(error: MQTTError.noSessionPresent)
-    }
-
-    /// Connect to MQTT server and run operations using the connection and then close it.
-    ///
-    /// - Parameters:
-    ///   - address: Internet address of the MQTT server.
-    ///   - configuration: Configuration of the MQTT connection.
-    ///   - session: The ``MQTTSession`` to use for the connection.
-    ///   - eventLoop: EventLoop to run the connection on.
-    ///   - logger: Logger to use for the connection.
-    ///   - operation: Closure handling the MQTT connection.
-    /// - Returns: Value returned from the operation closure.
-    public static func withConnection<Value>(
-        address: MQTTServerAddress,
-        configuration: MQTTConnectionConfiguration = .init(),
-        session: MQTTSession,
-        eventLoop: any EventLoop = MultiThreadedEventLoopGroup.singleton.any(),
-        logger: Logger,
-        operation: (MQTTConnection) async throws -> Value
-    ) async throws -> Value {
-        try await Self.withConnection(
-            address: address,
-            configuration: configuration,
-            session: session,
-            eventLoop: eventLoop,
-            logger: logger
-        ) { connection, _ in
-            try await operation(connection)
-        }
     }
 
     /// Publish message to topic.

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -400,8 +400,7 @@ struct IntegrationTests {
             address: .hostname(Self.hostname),
             identifier: "sessionPresent",
             logger: Logger(label: #function).withLogLevel(.trace)
-        ) { connection, sessionPresent in
-            #expect(sessionPresent == false)
+        ) { connection in
             try await connection.ping()
         }
 
@@ -671,7 +670,7 @@ struct IntegrationTests {
                     address: .hostname(Self.hostname),
                     session: session,
                     logger: Logger(label: #function).withLogLevel(.trace)
-                ) { connection in
+                ) { connection, sessionPresent in
                     async let _ = connection.publish(to: "testInflight", payload: ByteBuffer(string: "test"), qos: .exactlyOnce)
                     connection.close()
                 }
@@ -682,7 +681,7 @@ struct IntegrationTests {
                     address: .hostname(Self.hostname),
                     session: session,
                     logger: Logger(label: #function).withLogLevel(.trace)
-                ) { connection in
+                ) { connection, sessionPresent in
                     try await connection.ping()
                 }
 
@@ -704,7 +703,7 @@ struct IntegrationTests {
                         address: .hostname(Self.hostname),
                         session: session,
                         logger: Logger(label: #function).withLogLevel(.trace)
-                    ) { connection in
+                    ) { connection, sessionPresent in
                         try await connection.subscribe(to: [.init(topicFilter: "multipleConnWithSession1", qos: .atMostOnce)]) { subscription in
                             for try await _ in subscription {}
                         }
@@ -716,7 +715,7 @@ struct IntegrationTests {
                         address: .hostname(Self.hostname),
                         session: session,
                         logger: Logger(label: #function).withLogLevel(.trace)
-                    ) { connection in
+                    ) { connection, sessionPresent in
                         try await connection.subscribe(to: [.init(topicFilter: "multipleConnWithSession2", qos: .atMostOnce)]) { subscription in
                             for try await _ in subscription {}
                         }
@@ -873,9 +872,7 @@ struct IntegrationTests {
                     address: .hostname(Self.hostname),
                     identifier: "closeSubscriptionsNoSessionPresent",
                     logger: Logger(label: #function).withLogLevel(.trace)
-                ) { connection, sessionPresent in
-                    // `sessionPresent` should be false as this connection is with `cleanSession` true
-                    #expect(!sessionPresent)
+                ) { connection in
                     try await connection.ping()
                 }
 
@@ -926,7 +923,7 @@ struct IntegrationTests {
                     address: .hostname(Self.hostname),
                     session: session,
                     logger: logger
-                ) { connection in
+                ) { connection, sessionPresent in
                     try await withThrowingTaskGroup { group in
                         group.addTask {
                             _ = await #expect(throws: MQTTError.self) {

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -91,7 +91,7 @@ struct IntegrationV5Tests {
             configuration: .init(versionConfiguration: .v5_0()),
             session: session,
             logger: Logger(label: #function).withLogLevel(.trace)
-        ) { connection in
+        ) { connection, sessionPresent in
         }
         #expect(try !session.storage.borrow { $0.clientID }.isEmpty)
     }
@@ -321,7 +321,7 @@ struct IntegrationV5Tests {
                 configuration: .init(versionConfiguration: .v5_0(connectProperties: [.authenticationMethod("test")])),
                 identifier: "badAuthenticationMethodV5",
                 logger: Logger(label: #function).withLogLevel(.trace)
-            ) { _, _ in }
+            ) { _ in }
         }
     }
 


### PR DESCRIPTION
The connection being closed by the server is currently only known when the client performs some action or the connection is waiting on a subscription. If the client is doing other work this will not be cancelled. Adding a waitOnClose will allow users to catch this situation.

I also decided to remove two of the withConnection functions to clean things up a little.
