### PR TITLE
Clean start on empty session, Don't cancel MQTTSession.subscriptionsQueue iteration

### DIFF
--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -281,7 +281,23 @@ public final actor MQTTConnection: Sendable {
             }
         let connection = try await future.get()
         try await connection.waitOnInitialized()
-        let sessionPresent = try await connection.sendConnect(clientID: _session.clientID, cleanSession: session == nil)
+
+        // cleanSession means different things for v3.1.1 and v5.0. If you set cleanSession in v3.1.1 it will
+        // also not save the session, but you can set cleanSession (called cleanStart in v5) in v5 as it
+        // will save the session if the session expiry interval is set. Therefore we can start with clean start
+        // if our session is empty on v5
+        let cleanSession =
+            if let session {
+                switch configuration.version {
+                case .v3_1_1:
+                    false
+                case .v5_0:
+                    session.subscriptions.subscriptionIDMap.isEmpty && session.inflight.packets.isEmpty
+                }
+            } else {
+                true
+            }
+        let sessionPresent = try await connection.sendConnect(clientID: _session.clientID, cleanSession: cleanSession)
         return (connection, sessionPresent)
     }
 
@@ -302,7 +318,7 @@ public final actor MQTTConnection: Sendable {
             case .v3_1_1(let will):
                 will.map {
                     MQTTPublishInfo(
-                        qos: .atMostOnce,
+                        qos: $0.qos,
                         retain: $0.retain,
                         dup: false,
                         topicName: $0.topicName,
@@ -313,7 +329,7 @@ public final actor MQTTConnection: Sendable {
             case .v5_0(_, _, let will, _):
                 will.map {
                     MQTTPublishInfo(
-                        qos: .atMostOnce,
+                        qos: $0.qos,
                         retain: $0.retain,
                         dup: false,
                         topicName: $0.topicName,

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -170,7 +170,7 @@ public final actor MQTTConnection: Sendable {
                 if !sessionPresent { await connection.closeSubscriptions() }
 
                 // stick this in an unstructured task to avoid cancellation on iterating the subscribe
-                // request queue. Will use `withTaskCancellationShield` when Swift 6.4 comes out
+                // request queue. TODO: use `withTaskCancellationShield` when Swift 6.4 comes out
                 let task = Task { await connection.handleSessionSubscriptionTasks(session: session) }
                 do {
                     let value = try await operation(connection, sessionPresent)

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -168,15 +168,19 @@ public final actor MQTTConnection: Sendable {
                     return (sessionStorage, .failure(error))
                 }
                 if !sessionPresent { await connection.closeSubscriptions() }
+
+                // stick this in an unstructured task to avoid cancellation on iterating the subscribe
+                // request queue. Will use `withTaskCancellationShield` when Swift 6.4 comes out
+                let task = Task { await connection.handleSessionSubscriptionTasks(session: session) }
                 do {
-                    let result: Value = try await withThrowingTaskGroup { group in
-                        group.addTask { try await connection.handleSessionSubscriptionTasks(session: session) }
-                        defer { group.cancelAll() }
-                        return try await operation(connection, sessionPresent)
-                    }
+                    let value = try await operation(connection, sessionPresent)
+                    session.subscriptionsQueueContinuation.yield(.cancel)
+                    await task.value
                     let sessionStorage = await connection.closeAndCleanup()
-                    return (sessionStorage, .success(result))
+                    return (sessionStorage, .success(value))
                 } catch {
+                    session.subscriptionsQueueContinuation.yield(.cancel)
+                    await task.value
                     let sessionStorage = await connection.closeAndCleanup()
                     return (sessionStorage, .failure(error))
                 }
@@ -364,7 +368,7 @@ public final actor MQTTConnection: Sendable {
     }
 
     /// Iterates over subscription tasks in the session queue and handles them.
-    func handleSessionSubscriptionTasks(session: MQTTSession) async throws {
+    func handleSessionSubscriptionTasks(session: MQTTSession) async {
         for await task in session.subscriptionsQueue {
             switch task {
             case .subscribe(let queuedSubscription):
@@ -385,10 +389,15 @@ public final actor MQTTConnection: Sendable {
                     _ = try await promise.futureResult.get()
                 } catch {
                     queuedSubscription.continuation.finish(throwing: error)
-                    throw error
                 }
             case .unsubscribe(let queuedUnsubscription):
-                try await self.unsubscribe(id: queuedUnsubscription.id, properties: queuedUnsubscription.properties)
+                do {
+                    try await self.unsubscribe(id: queuedUnsubscription.id, properties: queuedUnsubscription.properties)
+                } catch {
+                    self.logger.info("Error unsubscribing from channel", metadata: ["mqtt_subscription": .stringConvertible(queuedUnsubscription.id)])
+                }
+            case .cancel:
+                return
             }
         }
     }

--- a/Sources/MQTTNIO/Session/MQTTSession.swift
+++ b/Sources/MQTTNIO/Session/MQTTSession.swift
@@ -80,6 +80,7 @@ extension MQTTSession {
     enum SessionSubscriptionTask: Sendable {
         case subscribe(QueuedSubscription)
         case unsubscribe(QueuedUnsubscription)
+        case cancel
     }
 
 }

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -263,6 +263,7 @@ struct IntegrationV5Tests {
         }
 
         try await withThrowingTaskGroup { group in
+            // Add a subscription to the session to ensure it doesn't always send cleanStart
             group.addTask {
                 try await session.subscribe(to: [.init(topicFilter: "test", qos: .atMostOnce)]) { sub in
                     var iterator = sub.makeAsyncIterator()

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -246,7 +246,6 @@ struct IntegrationV5Tests {
     @Test("Session Expiry Interval")
     func sessionExpiryInterval() async throws {
         let session = MQTTSession(clientID: "sessionExpiryIntervalV5", logger: Logger(label: #function).withLogLevel(.trace))
-
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(
@@ -263,53 +262,66 @@ struct IntegrationV5Tests {
             try await connection.ping()
         }
 
-        try await MQTTConnection.withConnection(
-            address: .hostname(Self.hostname),
-            configuration: .init(
-                versionConfiguration: .v5_0(
-                    connectProperties: [.sessionExpiryInterval(3600)],
-                    disconnectProperties: [.sessionExpiryInterval(3600)]
-                )
-            ),
-            session: session,
-            logger: Logger(label: #function).withLogLevel(.trace)
-        ) { connection, sessionPresent in
-            // We used the same session in the previous connection,
-            // but the Session Expiry Interval was set to 0
-            #expect(sessionPresent == false)
-            try await connection.ping()
-        }
+        try await withThrowingTaskGroup { group in
+            group.addTask {
+                try await session.subscribe(to: [.init(topicFilter: "test", qos: .atMostOnce)]) { sub in
+                    var iterator = sub.makeAsyncIterator()
+                    _ = try? await iterator.next()
+                }
+            }
+            group.addTask {
+                try await MQTTConnection.withConnection(
+                    address: .hostname(Self.hostname),
+                    configuration: .init(
+                        versionConfiguration: .v5_0(
+                            connectProperties: [.sessionExpiryInterval(3600)],
+                            disconnectProperties: [.sessionExpiryInterval(3600)]
+                        )
+                    ),
+                    session: session,
+                    logger: Logger(label: #function).withLogLevel(.trace)
+                ) { connection, sessionPresent in
+                    // We used the same session in the previous connection,
+                    // but the Session Expiry Interval was set to 0
+                    #expect(sessionPresent == false)
+                    try await connection.ping()
+                    try await Task.sleep(for: .milliseconds(500))
+                }
 
-        try await MQTTConnection.withConnection(
-            address: .hostname(Self.hostname),
-            configuration: .init(
-                versionConfiguration: .v5_0(
-                    connectProperties: [.sessionExpiryInterval(4)],
-                    disconnectProperties: [.sessionExpiryInterval(4)]
-                )
-            ),
-            session: session,
-            logger: Logger(label: #function).withLogLevel(.trace)
-        ) { connection, sessionPresent in
-            // We used the same session in the previous connection,
-            // and the Session Expiry Interval was long enough for the session to still be valid
-            #expect(sessionPresent == true)
-            try await connection.ping()
-        }
+                try await MQTTConnection.withConnection(
+                    address: .hostname(Self.hostname),
+                    configuration: .init(
+                        versionConfiguration: .v5_0(
+                            connectProperties: [.sessionExpiryInterval(4)],
+                            disconnectProperties: [.sessionExpiryInterval(4)]
+                        )
+                    ),
+                    session: session,
+                    logger: Logger(label: #function).withLogLevel(.trace)
+                ) { connection, sessionPresent in
+                    // We used the same session in the previous connection,
+                    // and the Session Expiry Interval was long enough for the session to still be valid
+                    #expect(sessionPresent == true)
+                    try await connection.ping()
+                }
 
-        // Wait for the session to expire
-        try await Task.sleep(for: .seconds(5))
+                // Wait for the session to expire
+                try await Task.sleep(for: .seconds(5))
 
-        try await MQTTConnection.withConnection(
-            address: .hostname(Self.hostname),
-            configuration: .init(versionConfiguration: .v5_0()),
-            session: session,
-            logger: Logger(label: #function).withLogLevel(.trace)
-        ) { connection, sessionPresent in
-            // We used the same session in the previous connection,
-            // but the session should have expired by now
-            #expect(sessionPresent == false)
-            try await connection.ping()
+                try await MQTTConnection.withConnection(
+                    address: .hostname(Self.hostname),
+                    configuration: .init(versionConfiguration: .v5_0()),
+                    session: session,
+                    logger: Logger(label: #function).withLogLevel(.trace)
+                ) { connection, sessionPresent in
+                    // We used the same session in the previous connection,
+                    // but the session should have expired by now
+                    #expect(sessionPresent == false)
+                    try await connection.ping()
+                }
+            }
+            try await group.next()
+            group.cancelAll()
         }
     }
 

--- a/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
+++ b/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
@@ -62,8 +62,8 @@ extension MQTTConnectionTests {
                         do {
                             _ = try await connection.sendConnect(clientID: sessionStorage.clientID, cleanSession: sessionStorage.clientID.isEmpty)
                             try await withThrowingTaskGroup { group in
-                                group.addTask { try await connection.handleSessionSubscriptionTasks(session: session) }
-                                defer { group.cancelAll() }
+                                group.addTask { await connection.handleSessionSubscriptionTasks(session: session) }
+                                defer { session.subscriptionsQueueContinuation.yield(.cancel) }
                                 try await clientOperation(connection)
                             }
                             let sessionStorage = await connection.closeAndCleanup()

--- a/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
+++ b/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
@@ -61,14 +61,23 @@ extension MQTTConnectionTests {
                     group.addTask {
                         do {
                             _ = try await connection.sendConnect(clientID: sessionStorage.clientID, cleanSession: sessionStorage.clientID.isEmpty)
-                            try await withThrowingTaskGroup { group in
-                                group.addTask { await connection.handleSessionSubscriptionTasks(session: session) }
-                                defer { session.subscriptionsQueueContinuation.yield(.cancel) }
-                                try await clientOperation(connection)
-                            }
+                        } catch {
+                            let sessionStorage = await connection.closeAndCleanup()
+                            return (sessionStorage, .failure(error))
+
+                        }
+                        // stick this in an unstructured task to avoid cancellation on iterating the subscribe
+                        // request queue. TODO: use `withTaskCancellationShield` when Swift 6.4 comes out
+                        let task = Task { await connection.handleSessionSubscriptionTasks(session: session) }
+                        do {
+                            try await clientOperation(connection)
+                            session.subscriptionsQueueContinuation.yield(.cancel)
+                            await task.value
                             let sessionStorage = await connection.closeAndCleanup()
                             return (sessionStorage, .success(()))
                         } catch {
+                            session.subscriptionsQueueContinuation.yield(.cancel)
+                            await task.value
                             let sessionStorage = await connection.closeAndCleanup()
                             return (sessionStorage, .failure(error))
                         }


### PR DESCRIPTION
This PR was meant to be simple. It would start a session with cleanStart if we had a v5 connection and the session provided was empty. This meant I had to change the SessionExpiryInterval test to add a subscription to the session otherwise it'd keep starting with a clean session. But....

I couldn't get the session subscription to work and this was because when I ended the first connection it cancelled the MQTTSession.subscription iteration, which ends the stream. So any subsequent session subscription requests were ignored. So I have to ensure iterating MQTTSession.subscription is never cancelled.

First I had to have a way to end iterating it, so I added a new request `.cancelled`, which would stop iterating the queue. Secondly I had to protect the iteration from receiving a task cancellation. Currently the only method to do this is run your code in an unstructured task so that is what I've done. When Swift 6.4 comes out I can use `withTaskCancellationShield`