### PR TITLE
Exit waitUntilNoActiveSubscriptions on connection close and cancellation

### DIFF
--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler+stateMachine.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler+stateMachine.swift
@@ -294,6 +294,19 @@ extension MQTTChannelHandler {
             }
         }
 
+        /// Is connection closed
+        @usableFromInline
+        func isClosed() -> Bool {
+            switch self.state {
+            case .uninitialized:
+                return false
+            case .initialized:
+                return false
+            case .closed:
+                return true
+            }
+        }
+
         private static var uninitialized: Self {
             StateMachine(.uninitialized)
         }

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -225,17 +225,37 @@ public final actor MQTTConnection: Sendable {
     /// This function waits only for subscriptions that have been acknowledged by the server.
     ///
     /// If new subscriptions are opened while waiting, this function will also wait for those subscriptions to complete.
-    public func waitUntilNoActiveSubscriptions() async {
-        await withCheckedContinuation { continuation in
-            if self.channelHandler.session.subscriptions.subscriptionIDMap.isEmpty {
-                self.logger.trace("No active subscriptions to wait for")
-                continuation.resume()
-                return
+    ///
+    /// - Throws: If connection is closed while waiting it will throw the error that caused the connection to close
+    public func waitUntilNoActiveSubscriptions() async throws {
+        let id = Self.requestIDGenerator.next()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if self.channelHandler.session.subscriptions.subscriptionIDMap.isEmpty {
+                    self.logger.trace("No active subscriptions to wait for")
+                    continuation.resume()
+                    return
+                }
+                if self.channelHandler.stateMachine.isClosed() {
+                    continuation.resume(throwing: MQTTError.connectionClosed)
+                    return
+                }
+                self.logger.trace("Waiting for \(self.channelHandler.session.subscriptions.subscriptionIDMap.count) active subscriptions to complete")
+                self.channelHandler.session.subscriptions.addWaitForEmptySubscriptions(id: id, continuation: continuation)
             }
-            self.logger.trace("Waiting for \(self.channelHandler.session.subscriptions.subscriptionIDMap.count) active subscriptions to complete")
-            self.channelHandler.session.subscriptions.emptySubscriptionsContinuations.append(continuation)
+        } onCancel: {
+            self.cancelWaitForEmptySubscriptions(id: id)
         }
         self.logger.trace("All active subscriptions completed")
+    }
+
+    @usableFromInline
+    nonisolated func cancelWaitForEmptySubscriptions(id: Int) {
+        self.channel.eventLoop.execute {
+            self.assumeIsolated { this in
+                this.channelHandler.session.subscriptions.cancelWaitForEmptySubscriptions(id: id)
+            }
+        }
     }
 
     /// Connect to MQTT server and return the connection and whether there was a previous session present.

--- a/Sources/MQTTNIO/Subscriptions/MQTTSubscriptions.swift
+++ b/Sources/MQTTNIO/Subscriptions/MQTTSubscriptions.swift
@@ -14,8 +14,8 @@ struct MQTTSubscriptions: Sendable {
     var subscriptionMap: [TopicFilter: MQTTTopicStateMachine<SubscriptionRef>]
     let logger: Logger
 
-    /// See ``MQTTSession/waitUntilNoActiveSubscriptions()``
-    var emptySubscriptionsContinuations: [CheckedContinuation<Void, Never>]
+    /// See ``MQTTConnection/waitUntilNoActiveSubscriptions()``
+    var emptySubscriptionsContinuations: [Int: CheckedContinuation<Void, any Error>]
 
     static let globalSubscriptionID = Atomic<UInt32>(0)
 
@@ -23,7 +23,7 @@ struct MQTTSubscriptions: Sendable {
         self.subscriptionIDMap = [:]
         self.logger = logger
         self.subscriptionMap = [:]
-        self.emptySubscriptionsContinuations = []
+        self.emptySubscriptionsContinuations = [:]
     }
 
     /// We received a message
@@ -70,10 +70,13 @@ struct MQTTSubscriptions: Sendable {
         // then we should close also the subscriptions opened by the session
         let noSessionPresent = if case MQTTError.noSessionPresent = error { true } else { false }
 
-        for subscription in subscriptionIDMap.values where !subscription.openedBySession || noSessionPresent {
+        // send error to subscription
+        for subscription in self.subscriptionIDMap.values where !subscription.openedBySession || noSessionPresent {
             subscription.sendError(error)
             self.removeSubscription(id: subscription.id)
         }
+
+        self.resumeWaitForEmptySubscriptions(.failure(error))
     }
 
     static func getSubscriptionID() -> UInt32 {
@@ -147,11 +150,7 @@ struct MQTTSubscriptions: Sendable {
         defer {
             self.subscriptionIDMap[id] = nil
             if self.subscriptionIDMap.isEmpty {
-                // See `MQTTSession.waitUntilNoActiveSubscriptions()`
-                for continuation in self.emptySubscriptionsContinuations {
-                    continuation.resume()
-                }
-                self.emptySubscriptionsContinuations.removeAll()
+                self.resumeWaitForEmptySubscriptions(.success(()))
             }
         }
         switch subscription.version {
@@ -194,6 +193,23 @@ struct MQTTSubscriptions: Sendable {
             break
         }
         subscriptionIDMap[id] = nil
+    }
+
+    mutating func addWaitForEmptySubscriptions(id: Int, continuation: CheckedContinuation<Void, any Error>) {
+        self.emptySubscriptionsContinuations[id] = continuation
+    }
+
+    mutating func cancelWaitForEmptySubscriptions(id: Int) {
+        let continuation = self.emptySubscriptionsContinuations.removeValue(forKey: id)
+        continuation?.resume(throwing: CancellationError())
+    }
+
+    mutating func resumeWaitForEmptySubscriptions(_ result: Result<Void, any Error>) {
+        // send error to empty subscription continuation
+        for cont in self.emptySubscriptionsContinuations.values {
+            cont.resume(with: result)
+        }
+        self.emptySubscriptionsContinuations.removeAll()
     }
 }
 

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -1178,9 +1178,19 @@ struct IntegrationTests {
         ) { connection, sessionPresent in
             try await connection.publish(to: "test", payload: .init(), qos: .atLeastOnce)
             await stream.first { _ in true }
-            async let _ = connection.waitUntilNoActiveSubscriptions()
+            let (stream2, cont2) = AsyncStream.makeStream(of: Void.self)
+            await withThrowingTaskGroup { group in
+                group.addTask {
+                    cont2.yield()
+                    await #expect(throws: CancellationError.self) {
+                        try await connection.waitUntilNoActiveSubscriptions()
+                    }
+                }
+                await stream2.first { _ in true }
+                try? await Task.sleep(for: .milliseconds(50))
+                group.cancelAll()
+            }
         }
-
     }
 
     static let rootPath = #filePath

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -1120,7 +1120,7 @@ struct IntegrationTests {
         // Make an initial connection with `cleanSession` to clear any existing session state
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "waitUntilNoActiveSubscriptions",
+            identifier: "cancelActiveSubscriptionsWait",
             logger: logger
         ) { connection in
             try await connection.ping()

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -1187,7 +1187,6 @@ struct IntegrationTests {
                     }
                 }
                 await stream2.first { _ in true }
-                try? await Task.sleep(for: .milliseconds(50))
                 group.cancelAll()
             }
         }

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -427,11 +427,11 @@ struct IntegrationTests {
     @Test("Subscribe to All Topics", .disabled(if: ProcessInfo.processInfo.environment["CI"] != nil))
     func subscribeAll() async throws {
         try await MQTTConnection.withConnection(
-            address: .hostname("test.mosquitto.org"),
+            address: .hostname("broker.hivemq.com"),
             identifier: "subscribeAll",
             logger: Logger(label: #function).withLogLevel(.trace)
         ) { connection in
-            try await connection.subscribe(to: [.init(topicFilter: "#", qos: .exactlyOnce)]) { subscription in
+            try await connection.subscribe(to: [.init(topicFilter: "test/#", qos: .exactlyOnce)]) { subscription in
                 try await Task.sleep(for: .seconds(5))
             }
         }
@@ -1101,7 +1101,7 @@ struct IntegrationTests {
                             // Wait until the session subscription is active
                             await sessionStream.first { _ in true }
 
-                            await connection.waitUntilNoActiveSubscriptions()
+                            try await connection.waitUntilNoActiveSubscriptions()
                         }
 
                         try await connectionGroup.waitForAll()
@@ -1111,6 +1111,76 @@ struct IntegrationTests {
 
             try await group.waitForAll()
         }
+    }
+
+    @Test("Cancel Active Subscriptions Wait On Close")
+    func cancelActiveSubscriptionsWait() async throws {
+        let logger = Logger(label: #function).withLogLevel(.trace)
+
+        // Make an initial connection with `cleanSession` to clear any existing session state
+        try await MQTTConnection.withConnection(
+            address: .hostname(Self.hostname),
+            identifier: "waitUntilNoActiveSubscriptions",
+            logger: logger
+        ) { connection in
+            try await connection.ping()
+        }
+
+        let (stream, cont) = AsyncStream.makeStream(of: Void.self)
+        let session = MQTTSession(clientID: "cancelActiveSubscriptionsWait", logger: logger)
+        async let _ = session.subscribe(to: [.init(topicFilter: "test", qos: .atLeastOnce)]) { sub in
+            for try await _ in sub {
+                cont.yield()
+            }
+        }
+
+        // expect waitUntilNoActiveSubscriptions to throw error immediately as the connection is closed
+        await #expect(throws: MQTTError.connectionClosed) {
+            try await MQTTConnection.withConnection(
+                address: .hostname(Self.hostname),
+                session: session,
+                logger: logger
+            ) { connection, sessionPresent in
+                // make sure the subscriptions have been sent before sending a publish
+                try await Task.sleep(for: .milliseconds(50))
+                try await connection.publish(to: "test", payload: .init(), qos: .atLeastOnce)
+                await stream.first { _ in true }
+                connection.close()
+                await connection.waitOnClose()
+                try await connection.waitUntilNoActiveSubscriptions()
+            }
+        }
+
+        // expect waitUntilNoActiveSubscriptions to throw error when the connection is closed
+        await #expect(throws: MQTTError.serverClosedConnection) {
+            try await MQTTConnection.withConnection(
+                address: .hostname(Self.hostname),
+                session: session,
+                logger: logger
+            ) { connection, sessionPresent in
+                try await connection.publish(to: "test", payload: .init(), qos: .atLeastOnce)
+                await stream.first { _ in true }
+                try await withThrowingTaskGroup { group in
+                    group.addTask {
+                        try await Task.sleep(for: .milliseconds(50))
+                        connection.close()
+                    }
+                    try await connection.waitUntilNoActiveSubscriptions()
+                }
+            }
+        }
+
+        // expect waitUntilNoActiveSubscriptions to throw error as it has been cancelled
+        try await MQTTConnection.withConnection(
+            address: .hostname(Self.hostname),
+            session: session,
+            logger: logger
+        ) { connection, sessionPresent in
+            try await connection.publish(to: "test", payload: .init(), qos: .atLeastOnce)
+            await stream.first { _ in true }
+            async let _ = connection.waitUntilNoActiveSubscriptions()
+        }
+
     }
 
     static let rootPath = #filePath

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -1035,7 +1035,7 @@ struct IntegrationTests {
 
     @Test("Wait Until No Active Subscriptions")
     func waitUntilNoActiveSubscriptions() async throws {
-        let logger = Logger(label: #function).withLogLevel(.trace)
+        let logger = Logger(label: "Integration.\(#function)").withLogLevel(.trace)
 
         // Make an initial connection with `cleanSession` to clear any existing session state
         try await MQTTConnection.withConnection(

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -448,12 +448,12 @@ struct IntegrationV5Tests {
     @Test("Subscribe to All Topics", .disabled(if: ProcessInfo.processInfo.environment["CI"] != nil))
     func subscribeAll() async throws {
         try await MQTTConnection.withConnection(
-            address: .hostname("test.mosquitto.org"),
+            address: .hostname("broker.hivemq.com"),
             configuration: .init(versionConfiguration: .v5_0()),
             identifier: "subscribeAllV5",
             logger: Logger(label: #function).withLogLevel(.trace)
         ) { connection in
-            try await connection.v5.subscribe(to: [.init(topicFilter: "#", qos: .exactlyOnce)]) { _ in
+            try await connection.v5.subscribe(to: [.init(topicFilter: "test/#", qos: .exactlyOnce)]) { _ in
                 try await Task.sleep(for: .seconds(5))
             }
         }

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -634,8 +634,6 @@ struct MQTTConnectionTests {
             [.init(topicFilter: "testTopic3", qos: .atMostOnce)],
         ]
 
-        let (stream, continuation) = AsyncStream.makeStream(of: Void.self)
-
         try await withTestSessionSubscriptions(
             to: subscribeInfos,
             session: session,
@@ -645,14 +643,8 @@ struct MQTTConnectionTests {
             let event = try #require(try await iterator.next())
             #expect(event.payload == ByteBuffer(string: "TestPayload"))
         } client: { connection in
-            // Wait until all subscriptions are active
-            await stream.first { _ in true }
-
             try await connection.waitUntilNoActiveSubscriptions()
         } server: { channel in
-            // Signal that all subscriptions are active
-            continuation.yield()
-
             for subscribeInfo in subscribeInfos {
                 // Send PUBLISH
                 let publish = MQTTPublishPacket(

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -648,7 +648,7 @@ struct MQTTConnectionTests {
             // Wait until all subscriptions are active
             await stream.first { _ in true }
 
-            await connection.waitUntilNoActiveSubscriptions()
+            try await connection.waitUntilNoActiveSubscriptions()
         } server: { channel in
             // Signal that all subscriptions are active
             continuation.yield()
@@ -674,7 +674,7 @@ struct MQTTConnectionTests {
     func waitWithNoActiveSubscriptions() async throws {
         try await withTestMQTTServer(logger: Logger(label: #function).withLogLevel(.trace)) { connection in
             // Should return immediately as there are no active subscriptions
-            await connection.waitUntilNoActiveSubscriptions()
+            try await connection.waitUntilNoActiveSubscriptions()
         } server: { _ in
         }
     }

--- a/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
+++ b/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
@@ -263,6 +263,7 @@ extension MQTTConnectionTests {
         client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
     ) async throws {
+        let (stream, cont) = AsyncStream.makeStream(of: Void.self)
         try await withTestMQTTServer(session: session, logger: logger) { connection in
             try await withThrowingTaskGroup { group in
                 for subscribeInfo in subscribeInfos {
@@ -274,9 +275,8 @@ extension MQTTConnectionTests {
                 }
                 // Make sure all subscriptions have been called before running
                 // client operation
-                try await Task.sleep(for: .milliseconds(50))
+                await stream.first { _ in true }
                 try await clientOperation(connection)
-                group.cancelAll()
             }
         } server: { channel in
             for _ in subscribeInfos {
@@ -292,7 +292,7 @@ extension MQTTConnectionTests {
                 )
                 try await channel.writeInboundPacket(suback, version: .v3_1_1)
             }
-
+            cont.yield()
             try await serverOperation(channel)
 
             for _ in subscribeInfos {

--- a/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
+++ b/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
@@ -264,8 +264,7 @@ extension MQTTConnectionTests {
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
     ) async throws {
         try await withTestMQTTServer(session: session, logger: logger) { connection in
-            await withThrowingTaskGroup { group in
-                group.addTask { try await clientOperation(connection) }
+            try await withThrowingTaskGroup { group in
                 for subscribeInfo in subscribeInfos {
                     group.addTask {
                         try await session.subscribe(to: subscribeInfo) { subscription in
@@ -273,6 +272,11 @@ extension MQTTConnectionTests {
                         }
                     }
                 }
+                // Make sure all subscriptions have been called before running
+                // client operation
+                try await Task.sleep(for: .milliseconds(50))
+                try await clientOperation(connection)
+                group.cancelAll()
             }
         } server: { channel in
             for _ in subscribeInfos {


### PR DESCRIPTION
- waitUntilNoActiveSubscriptions now throws
- If connection is already closed, pass connectionClosed error to continuation 
- When MQTTSubscriptions.close(error:) is called pass the error to the stored continuations.
- Add an id with each continuation so it can be resumed by id. Needed to implement cancellation
- Add a test to check function returns in all situations