### PR TITLE
Report upgrade error if connection is closed while WS initial HTTP request is still active.

### DIFF
--- a/Sources/MQTTNIO/ChannelHandlers/WebSocketInitialRequest.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/WebSocketInitialRequest.swift
@@ -77,4 +77,8 @@ final class WebSocketInitialRequestHandler: ChannelInboundHandler, RemovableChan
         // we just pass nil as promise to reduce allocations.
         context.close(promise: nil)
     }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        self.upgradePromise.fail(ChannelError.ioOnClosedChannel)
+    }
 }

--- a/Sources/MQTTNIO/ChannelHandlers/WebSocketInitialRequest.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/WebSocketInitialRequest.swift
@@ -79,6 +79,8 @@ final class WebSocketInitialRequestHandler: ChannelInboundHandler, RemovableChan
     }
 
     func channelInactive(context: ChannelHandlerContext) {
+        // If channel is closed while this ChannelHandler is still active then we should
+        // fail the upgrade
         self.upgradePromise.fail(ChannelError.ioOnClosedChannel)
     }
 }

--- a/Sources/MQTTNIO/ChannelHandlers/WebSocketInitialRequest.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/WebSocketInitialRequest.swift
@@ -55,7 +55,6 @@ final class WebSocketInitialRequestHandler: ChannelInboundHandler, RemovableChan
         )
 
         context.write(self.wrapOutboundOut(.head(requestHead)), promise: nil)
-        context.write(self.wrapOutboundOut(.body(.byteBuffer(ByteBuffer()))), promise: nil)
         context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
     }
 

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -548,7 +548,7 @@ struct MQTTConnectionTests {
     }
 
     @Test("WebSocket Initial Request")
-    func webSocketInitialRequest() throws {
+    func webSocketInitialRequest() async throws {
         let el = EmbeddedEventLoop()
         defer { #expect(throws: Never.self) { try el.syncShutdownGracefully() } }
         let promise = el.makePromise(of: Void.self)
@@ -559,9 +559,8 @@ struct MQTTConnectionTests {
             upgradePromise: promise
         )
         let channel = EmbeddedChannel(handler: initialRequestHandler, loop: el)
-        try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 0)).wait()
+        try await channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 0)).get()
         let requestHead = try channel.readOutbound(as: HTTPClientRequestPart.self)
-        let requestBody = try channel.readOutbound(as: HTTPClientRequestPart.self)
         let requestEnd = try channel.readOutbound(as: HTTPClientRequestPart.self)
         switch requestHead {
         case .head(let head):
@@ -572,12 +571,6 @@ struct MQTTConnectionTests {
         default:
             Issue.record("Unexpected request head: \(String(describing: requestHead))")
         }
-        switch requestBody {
-        case .body(let data):
-            #expect(data == .byteBuffer(ByteBuffer()))
-        default:
-            Issue.record("Unexpected request body: \(String(describing: requestBody))")
-        }
         switch requestEnd {
         case .end(nil):
             break
@@ -585,7 +578,11 @@ struct MQTTConnectionTests {
             Issue.record("Unexpected request end: \(String(describing: requestEnd))")
         }
         _ = try channel.finish()
-        promise.succeed(())
+        // if the channel is made inactive while the WebSocketInitialRequestHandler is in the
+        // pipeline it should pass an error to the upgrade promise
+        await #expect(throws: ChannelError.ioOnClosedChannel) {
+            try await promise.futureResult.get()
+        }
     }
 
     @Test("Subscription with Session")


### PR DESCRIPTION
Previously WebSocket connections would just hang if the connection was closed during the upgrade