### PR TITLE
Add Swift Configuration support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       env:
         MOSQUITTO_SERVER: mosquitto
       run: |
-        swift test --enable-code-coverage --no-parallel
+        swift test --enable-code-coverage
     - name: Upload coverage data
       uses: vapor/swift-codecov-action@v0.3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       env:
         MOSQUITTO_SERVER: mosquitto
       run: |
-        swift test --enable-code-coverage
+        swift test --enable-code-coverage --no-parallel
     - name: Upload coverage data
       uses: vapor/swift-codecov-action@v0.3
       with:

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.26.0"),
         .package(url: "https://github.com/apple/swift-http-types.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.22.0"),
+        .package(url: "https://github.com/apple/swift-configuration.git", from: "1.1.0"),
     ],
     targets: [
         .target(
@@ -49,6 +50,7 @@ let package = Package(
                 .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
                 .product(name: "HTTPTypes", package: "swift-http-types"),
                 .product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
+                .product(name: "Configuration", package: "swift-configuration"),
             ],
             swiftSettings: defaultSwiftSettings
         ),

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -378,8 +378,8 @@ public final actor MQTTConnection: Sendable {
             cleanSession: cleanSession,
             keepAliveSeconds: UInt16(configuration.keepAliveInterval.components.seconds),
             clientIdentifier: clientID,
-            userName: configuration.authentication?.userName,
-            password: configuration.authentication?.password,
+            userName: configuration.userName,
+            password: configuration.password,
             properties: properties,
             will: publish
         )

--- a/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
@@ -210,8 +210,10 @@ extension MQTTConnectionConfiguration.TLS {
         )
         tlsConfiguration.trustRoots = nioSSLTrustRoots.map { .certificates($0) }
         self.base = .enable(.niossl(tlsConfiguration), tlsServerName: tlsServerName)
-        #endif
+        return
+        #else
         throw _TLSConfigError.missingConfiguration
+        #endif
     }
 }
 

--- a/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
@@ -10,11 +10,6 @@ public import Configuration
 import HTTPTypes
 import NIOCore
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import Foundation
-#endif
 #if canImport(Network)
 import NIOTransportServices
 #endif
@@ -41,9 +36,10 @@ extension MQTTConnectionConfiguration {
     /// - `userName` (string, optional): The user identifier used to authenticate against a secured MQTT server.
     /// - `password` (string, optional): The password used to authenticate against a secured MQTT server.
     /// - `tls.config` (string, optional): Whether to use `NIOSSL` or `NIOTransportServices`.
-    /// - `tls.certificateChain` (string, optional): TLS certificate chain in PEM format.
-    /// - `tls.privateKey` (string, optional): TLS private key in PEM format.
-    /// - `tls.trustRoots` (string, optional): TLS trust roots in PEM format.
+    /// - `tls.certificateChain` (string): TLS certificate chain in PEM format. Only applicable for `NIOSSL`.
+    /// - `tls.privateKey` (string): TLS private key, in PEM format for NIOSSL, or as a file path to a `.p12` file for NIOTransportServices.
+    /// - `tls.privateKeyPassword` (string): Password for the TLS private key. Only applicable for NIOTransportServices.
+    /// - `tls.trustRoots` (string, optional): TLS trust roots, in PEM format for NIOSSL, or as a file path to a `.der` file for NIOTransportServices.
     /// - `tls.serverName` (string, optional): Optional server name for SNI (Server Name Indication).
     /// - `webSocket.urlPath` (string, optional): The URL path to use when establishing the WebSocket connection.
     /// - `webSocket.maxFrameSize` (int, optional): The maximum frame size for the WebSocket connection.
@@ -149,9 +145,10 @@ extension MQTTConnectionConfiguration.TLS {
     ///
     /// ## Configuration keys
     /// - `tls.config` (string, optional): Whether to use `NIOSSL` or `NIOTransportServices`.
-    /// - `tls.certificateChain` (string): TLS certificate chain in PEM format.
-    /// - `tls.privateKey` (string): TLS private key in PEM format.
-    /// - `tls.trustRoots` (string, optional): TLS trust roots in PEM format.
+    /// - `tls.certificateChain` (string): TLS certificate chain in PEM format. Only applicable for `NIOSSL`.
+    /// - `tls.privateKey` (string): TLS private key, in PEM format for NIOSSL, or as a file path to a `.p12` file for NIOTransportServices.
+    /// - `tls.privateKeyPassword` (string): Password for the TLS private key. Only applicable for NIOTransportServices.
+    /// - `tls.trustRoots` (string, optional): TLS trust roots, in PEM format for NIOSSL, or as a file path to a `.der` file for NIOTransportServices.
     /// - `tls.serverName` (string, optional): Optional server name for SNI (Server Name Indication).
     ///
     /// - Parameter config: The config reader to read configuration values from.
@@ -159,19 +156,16 @@ extension MQTTConnectionConfiguration.TLS {
     /// - Throws: ``MQTTConnectionConfiguration/TLS/TLSConfigError/incompatibleConfiguration`` if the configuration is not valid or not supported.
     init(config: ConfigReader) throws {
         let tlsConfig = config.scoped(to: "tls")
-
-        let certificateChainPEM = try tlsConfig.requiredString(forKey: "certificateChain")
-        let privateKeyPEM = try tlsConfig.requiredString(forKey: "privateKey")
-        let trustRootsPEM = tlsConfig.string(forKey: "trustRoots")
-
+        let privateKey = try tlsConfig.requiredString(forKey: "privateKey")
+        let trustRoots = tlsConfig.string(forKey: "trustRoots")
         let tlsServerName = tlsConfig.string(forKey: "serverName")
-
         switch tlsConfig.string(forKey: "config")?.lowercased() {
         #if os(macOS) || os(Linux) || os(Android)
         case "niossl":
+            let certificateChainPEM = try tlsConfig.requiredString(forKey: "certificateChain")
             let certificateChain = try NIOSSLCertificate.fromPEMBytes([UInt8](certificateChainPEM.utf8))
-            let privateKey = try NIOSSLPrivateKey(bytes: [UInt8](privateKeyPEM.utf8), format: .pem)
-            let trustRoots = try trustRootsPEM.map { try NIOSSLCertificate.fromPEMBytes([UInt8]($0.utf8)) }
+            let privateKey = try NIOSSLPrivateKey(bytes: [UInt8](privateKey.utf8), format: .pem)
+            let trustRoots = try trustRoots.map { try NIOSSLCertificate.fromPEMBytes([UInt8]($0.utf8)) }
             var tlsConfiguration = TLSConfiguration.makeServerConfiguration(
                 certificateChain: certificateChain.map { .certificate($0) },
                 privateKey: .privateKey(privateKey)
@@ -181,8 +175,14 @@ extension MQTTConnectionConfiguration.TLS {
         #endif
         #if canImport(Network)
         case "ts", "niots", "niotransportservices":
-            // TODO: Support NIOTransportServices
-            throw TLSConfigError.incompatibleConfiguration
+            let privateKeyConfig = try TSTLSConfiguration.Identity.p12(
+                filename: privateKey,
+                password: tlsConfig.requiredString(forKey: "privateKeyPassword", isSecret: true)
+            )
+            guard let trustRoots else { throw TLSConfigError.incompatibleConfiguration }
+            let trustRootsConfig = try TSTLSConfiguration.Certificates.der(trustRoots)
+            let tlsConfiguration = TSTLSConfiguration(trustRoots: trustRootsConfig, clientIdentity: privateKeyConfig)
+            self.base = .enable(.ts(tlsConfiguration), tlsServerName: tlsServerName)
         #endif
         default:
             throw TLSConfigError.incompatibleConfiguration

--- a/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
@@ -38,6 +38,7 @@ extension MQTTConnectionConfiguration {
     /// ### TLS configuration keys
     /// - `tls.serverName` (string, optional): Optional server name for SNI (Server Name Indication). Valid for both `NIOSSL` and `NIOTransportServices`.
     /// ### NIOTransportServices specific configuration keys (takes precedence over NIOSSL if available)
+    /// - `tls.niots.serverName` (string, optional): Name alias for `tls.serverName`. If both `tls.serverName` and `tls.niots.serverName` are provided, the value from `tls.serverName` will be used.
     /// - `tls.niots.privateKey` (string): TLS private key as a file path to a `.p12` file for NIOTransportServices.
     /// - `tls.niots.privateKeyPassword` (string): Password for the TLS private key. Only applicable for NIOTransportServices.
     /// - `tls.niots.trustRoots` (string, optional): TLS trust roots as a file path to a `.der` file for NIOTransportServices.
@@ -163,6 +164,10 @@ extension TSTLSConfiguration {
 #endif
 
 extension MQTTConnectionConfiguration.TLS {
+    private enum _TLSConfigError: Error {
+        case missingConfiguration
+    }
+
     /// Creates a new TLS configuration using values from the provided reader.
     ///
     /// If the `niots` scoped configuration is present, and NIOTransportServices is available, it will be used as it takes precedence over the `NIOSSL` configuration.
@@ -171,6 +176,7 @@ extension MQTTConnectionConfiguration.TLS {
     /// ## Configuration keys
     /// - `serverName` (string, optional): Optional server name for SNI (Server Name Indication). Valid for both `NIOSSL` and `NIOTransportServices`.
     /// ### NIOTransportServices specific configuration keys
+    /// - `niots.serverName` (string, optional): Name alias for `serverName`. If both `serverName` and `niots.serverName` are provided, the value from `serverName` will be used.
     /// - `niots.privateKey` (string): TLS private key as a file path to a `.p12` file for NIOTransportServices.
     /// - `niots.privateKeyPassword` (string): Password for the TLS private key. Only applicable for NIOTransportServices.
     /// - `niots.trustRoots` (string, optional): TLS trust roots as a file path to a `.der` file for NIOTransportServices.
@@ -180,6 +186,8 @@ extension MQTTConnectionConfiguration.TLS {
     /// - `trustRoots` (string, optional): TLS trust roots, in PEM format for NIOSSL.
     ///
     /// - Parameter config: The config reader to read configuration values from.
+    ///
+    /// - Throws: An internal error type if no compatible TLS configuration is found in the provided reader.
     init(config: ConfigReader) throws {
         let tlsServerName = config.string(forKey: "serverName")
         #if canImport(Network)
@@ -188,8 +196,7 @@ extension MQTTConnectionConfiguration.TLS {
             self.base = .enable(.ts(tsTLSConfiguration), tlsServerName: tlsServerName ?? nioTSConfigReader.string(forKey: "serverName"))
             return
         }
-        #endif
-        #if os(macOS) || os(Linux) || os(Android)
+        #elseif os(macOS) || os(Linux) || os(Android)
         let privateKey = try config.requiredString(forKey: "privateKey")
         let trustRoots = config.string(forKey: "trustRoots")
         let certificateChainPEM = try config.requiredString(forKey: "certificateChain")
@@ -203,6 +210,7 @@ extension MQTTConnectionConfiguration.TLS {
         tlsConfiguration.trustRoots = nioSSLTrustRoots.map { .certificates($0) }
         self.base = .enable(.niossl(tlsConfiguration), tlsServerName: tlsServerName)
         #endif
+        throw _TLSConfigError.missingConfiguration
     }
 }
 

--- a/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
@@ -1,0 +1,252 @@
+//
+// This source file is part of the MQTTNIO project
+// Copyright (c) 2020-2026 the MQTTNIO authors
+//
+// See LICENSE for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+public import Configuration
+import HTTPTypes
+import NIOCore
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+#if canImport(Network)
+import NIOTransportServices
+#endif
+#if os(macOS) || os(Linux) || os(Android)
+import NIOSSL
+#endif
+
+extension MQTTConnectionConfiguration {
+    /// Creates a new MQTT connection configuration using values from the provided reader.
+    ///
+    /// ## Configuration keys
+    /// - `version` (string, optional, default: `"v3_1_1"`): Version of the MQTT server.
+    /// - `will.topicName` (string, optional): Topic Name of the Will Message.
+    /// - `will.payload` (bytes, optional): Payload of the Will Message.
+    /// - `will.qos` (int, optional): QoS level of the Will Message.
+    /// - `will.retain` (bool, optional, default: `false`): Specifies if the Will Message is to be retained when it is published.
+    /// - `keepAliveInterval` (int, optional, default: `90`): MQTT keep alive period, in seconds.
+    /// - `ping` (int/string, optional): Configuration for sending `PINGREQ` messages.
+    ///     If the value is `"disable"`, the ping configuration will be ``MQTTConnectionConfiguration/PingConfiguration/disable``.
+    ///     If the value is an integer, that will be the amount of seconds passed to ``MQTTConnectionConfiguration/PingConfiguration/pingInterval(_:)``.
+    ///     For any other value, or if there's no value, the ping configuration will be ``MQTTConnectionConfiguration/PingConfiguration/useServerKeepAlive``.
+    /// - `connectTimeout` (int, optional, default: `10`): Timeout for connecting to server, in seconds.
+    /// - `timeout` (int, optional): Timeout for server ACK responses.
+    /// - `userName` (string, optional): The user identifier used to authenticate against a secured MQTT server.
+    /// - `password` (string, optional): The password used to authenticate against a secured MQTT server.
+    /// - `tls.config` (string, optional): Whether to use `NIOSSL` or `NIOTransportServices`.
+    /// - `tls.certificateChain` (string, optional): TLS certificate chain in PEM format.
+    /// - `tls.privateKey` (string, optional): TLS private key in PEM format.
+    /// - `tls.trustRoots` (string, optional): TLS trust roots in PEM format.
+    /// - `tls.serverName` (string, optional): Optional server name for SNI (Server Name Indication).
+    /// - `webSocket.urlPath` (string, optional): The URL path to use when establishing the WebSocket connection.
+    /// - `webSocket.maxFrameSize` (int, optional): The maximum frame size for the WebSocket connection.
+    /// - `webSocket.initialRequestHeaders` (string array, optional): Initial HTTP headers to include in the WebSocket handshake request.
+    ///     The string must be in the `<key>:<value>` format.
+    ///
+    /// - Parameter config: The config reader to read configuration values from.
+    public init(config: ConfigReader) {
+        switch config.string(forKey: "version") {
+        case "v5_0", "v5", "5_0", "5", "v5.0", "5.0":
+            self.versionConfiguration = .v5_0(will: try? .init(config: config))
+        case .none, .some:
+            self.versionConfiguration = .v3_1_1(will: try? .init(config: config))
+        }
+        self.keepAliveInterval = config.int(forKey: "keepAliveInterval", as: Duration.self, default: .seconds(90))
+        self.pingConfiguration = .init(config: config)
+        self.connectTimeout = config.int(forKey: "connectTimeout", as: Duration.self, default: .seconds(10))
+        self.timeout = config.int(forKey: "timeout", as: Duration.self)
+        self.userName = config.string(forKey: "userName")
+        self.password = config.string(forKey: "password", isSecret: true)
+        self.tls = (try? .init(config: config)) ?? .disable
+        self.webSocketConfiguration = .init(config: config)
+    }
+}
+
+extension MQTTQoS: ExpressibleByConfigInt {
+    public init?(configInt: Int) { self.init(rawValue: UInt8(configInt)) }
+    public var configInt: Int { Int(self.rawValue) }
+}
+
+extension MQTTConnectionConfiguration.VersionConfiguration.WillMessageV311 {
+    /// Creates a new Will Message for MQTT v3.1.1 using values from the provided reader.
+    ///
+    /// ## Configuration keys
+    /// - `will.topicName` (string): Topic Name of the Will Message.
+    /// - `will.payload` (bytes): Payload of the Will Message.
+    /// - `will.qos` (int): QoS level of the Will Message.
+    /// - `will.retain` (bool, optional, default: `false`): Specifies if the Will Message is to be retained when it is published.
+    ///
+    /// - Parameter config: The config reader to read configuration values from.
+    init(config: ConfigReader) throws {
+        let willConfig = config.scoped(to: "will")
+        self.init(
+            topicName: try willConfig.requiredString(forKey: "topicName"),
+            payload: .init(bytes: try willConfig.requiredBytes(forKey: "payload")),
+            qos: try willConfig.requiredInt(forKey: "qos", as: MQTTQoS.self),
+            retain: willConfig.bool(forKey: "retain", default: false)
+        )
+    }
+}
+
+extension MQTTConnectionConfiguration.VersionConfiguration.WillMessageV5 {
+    /// Creates a new Will Message for MQTT v5.0 using values from the provided reader.
+    ///
+    /// ## Configuration keys
+    /// - `will.topicName` (string): Topic Name of the Will Message.
+    /// - `will.payload` (bytes): Payload of the Will Message.
+    /// - `will.qos` (int): QoS level of the Will Message.
+    /// - `will.retain` (bool, optional, default: `false`): Specifies if the Will Message is to be retained when it is published.
+    ///
+    /// - Parameter config: The config reader to read configuration values from.
+    init(config: ConfigReader) throws {
+        let willConfig = config.scoped(to: "will")
+        self.init(
+            topicName: try willConfig.requiredString(forKey: "topicName"),
+            payload: .init(bytes: try willConfig.requiredBytes(forKey: "payload")),
+            qos: try willConfig.requiredInt(forKey: "qos", as: MQTTQoS.self),
+            retain: willConfig.bool(forKey: "retain", default: false)
+        )
+    }
+}
+
+extension MQTTConnectionConfiguration.PingConfiguration {
+    /// Creates a new Ping Configuration using values from the provided reader.
+    ///
+    /// ## Configuration keys
+    /// - `ping` (int/string, optional): Configuration for sending `PINGREQ` messages.
+    ///     If the value is `"disable"`, the ping configuration will be ``MQTTConnectionConfiguration/PingConfiguration/disable``.
+    ///     If the value is an integer, that will be the amount of seconds passed to ``MQTTConnectionConfiguration/PingConfiguration/pingInterval(_:)``.
+    ///     For any other value, or if there's no value, the ping configuration will be ``MQTTConnectionConfiguration/PingConfiguration/useServerKeepAlive``.
+    ///
+    /// - Parameter config: The config reader to read configuration values from.
+    init(config: ConfigReader) {
+        if let interval = config.int(forKey: "ping", as: Duration.self) {
+            self.base = .pingInterval(interval)
+        } else {
+            switch config.string(forKey: "ping") {
+            case "disable":
+                self.base = .disable
+            default:
+                self.base = .useServerKeepAlive
+            }
+        }
+    }
+}
+
+extension MQTTConnectionConfiguration.TLS {
+    enum TLSConfigError: Error {
+        case incompatibleConfiguration
+    }
+
+    /// Creates a new TLS configuration using values from the provided reader.
+    ///
+    /// ## Configuration keys
+    /// - `tls.config` (string, optional): Whether to use `NIOSSL` or `NIOTransportServices`.
+    /// - `tls.certificateChain` (string): TLS certificate chain in PEM format.
+    /// - `tls.privateKey` (string): TLS private key in PEM format.
+    /// - `tls.trustRoots` (string, optional): TLS trust roots in PEM format.
+    /// - `tls.serverName` (string, optional): Optional server name for SNI (Server Name Indication).
+    ///
+    /// - Parameter config: The config reader to read configuration values from.
+    ///
+    /// - Throws: ``MQTTConnectionConfiguration/TLS/TLSConfigError/incompatibleConfiguration`` if the configuration is not valid or not supported.
+    init(config: ConfigReader) throws {
+        let tlsConfig = config.scoped(to: "tls")
+
+        let certificateChainPEM = try tlsConfig.requiredString(forKey: "certificateChain")
+        let privateKeyPEM = try tlsConfig.requiredString(forKey: "privateKey")
+        let trustRootsPEM = tlsConfig.string(forKey: "trustRoots")
+
+        let tlsServerName = tlsConfig.string(forKey: "serverName")
+
+        switch tlsConfig.string(forKey: "config")?.lowercased() {
+        #if os(macOS) || os(Linux) || os(Android)
+        case "niossl":
+            let certificateChain = try NIOSSLCertificate.fromPEMBytes([UInt8](certificateChainPEM.utf8))
+            let privateKey = try NIOSSLPrivateKey(bytes: [UInt8](privateKeyPEM.utf8), format: .pem)
+            let trustRoots = try trustRootsPEM.map { try NIOSSLCertificate.fromPEMBytes([UInt8]($0.utf8)) }
+            var tlsConfiguration = TLSConfiguration.makeServerConfiguration(
+                certificateChain: certificateChain.map { .certificate($0) },
+                privateKey: .privateKey(privateKey)
+            )
+            tlsConfiguration.trustRoots = trustRoots.map { .certificates($0) }
+            self.base = .enable(.niossl(tlsConfiguration), tlsServerName: tlsServerName)
+        #endif
+        #if canImport(Network)
+        case "ts", "niots", "niotransportservices":
+            // TODO: Support NIOTransportServices
+            throw TLSConfigError.incompatibleConfiguration
+        #endif
+        default:
+            throw TLSConfigError.incompatibleConfiguration
+        }
+    }
+}
+
+struct ConfigHTTPField: ExpressibleByConfigString {
+    let name: HTTPField.Name
+    let value: String
+
+    init(name: HTTPField.Name, value: String) {
+        self.name = name
+        self.value = value
+    }
+
+    /// Creates a HTTP header from a configuration string.
+    ///
+    /// The configuration string must be in the `<key>:<value>` format.
+    ///
+    /// - Parameter configString: The configuration string to create the HTTP header from.
+    init?(configString: String) {
+        guard let colonIndex = configString.firstIndex(of: ":") else { return nil }
+        guard let name = HTTPField.Name(String(configString[..<colonIndex].trimmingWhitespace())) else { return nil }
+        let valueStartIndex = configString.index(after: colonIndex)
+        let value = String(configString[valueStartIndex...].trimmingWhitespace())
+        self.init(name: name, value: value)
+    }
+
+    var description: String { "\(name):\(value)" }
+}
+
+extension MQTTConnectionConfiguration.WebSocketConfiguration {
+    /// Creates a new WebSocket configuration using values from the provided reader.
+    ///
+    /// ## Configuration keys
+    /// - `webSocket.urlPath` (string, optional): The URL path to use when establishing the WebSocket connection.
+    /// - `webSocket.maxFrameSize` (int, optional): The maximum frame size for the WebSocket connection.
+    /// - `webSocket.initialRequestHeaders` (string array, optional): Initial HTTP headers to include in the WebSocket handshake request.
+    ///
+    /// - Parameter config: The config reader to read configuration values from.
+    init?(config: ConfigReader) {
+        let webSocketConfig = config.scoped(to: "webSocket")
+        let urlPath = webSocketConfig.string(forKey: "urlPath")
+        let maxFrameSize = webSocketConfig.int(forKey: "maxFrameSize")
+        let initialRequestHeaders: HTTPFields?
+        if let initialRequestHeadersArray = webSocketConfig.stringArray(forKey: "initialRequestHeaders", as: ConfigHTTPField.self) {
+            var headers = HTTPFields()
+            for header in initialRequestHeadersArray {
+                headers.append(.init(name: header.name, value: header.value))
+            }
+            initialRequestHeaders = headers
+        } else {
+            initialRequestHeaders = nil
+        }
+
+        if urlPath != nil || maxFrameSize != nil || initialRequestHeaders != nil {
+            self.init(
+                urlPath: urlPath ?? "/ws",
+                maxFrameSize: maxFrameSize ?? 1 << 14,
+                initialRequestHeaders: initialRequestHeaders ?? [:]
+            )
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
@@ -35,12 +35,17 @@ extension MQTTConnectionConfiguration {
     /// - `timeout` (int, optional): Timeout for server ACK responses.
     /// - `userName` (string, optional): The user identifier used to authenticate against a secured MQTT server.
     /// - `password` (string, optional): The password used to authenticate against a secured MQTT server.
-    /// - `tls.config` (string, optional): Whether to use `NIOSSL` or `NIOTransportServices`.
+    /// ### TLS configuration keys
+    /// - `tls.serverName` (string, optional): Optional server name for SNI (Server Name Indication). Valid for both `NIOSSL` and `NIOTransportServices`.
+    /// ### NIOTransportServices specific configuration keys (takes precedence over NIOSSL if available)
+    /// - `tls.niots.privateKey` (string): TLS private key as a file path to a `.p12` file for NIOTransportServices.
+    /// - `tls.niots.privateKeyPassword` (string): Password for the TLS private key. Only applicable for NIOTransportServices.
+    /// - `tls.niots.trustRoots` (string, optional): TLS trust roots as a file path to a `.der` file for NIOTransportServices.
+    /// ### NIOSSL specific configuration keys (used as fallback)
     /// - `tls.certificateChain` (string): TLS certificate chain in PEM format. Only applicable for `NIOSSL`.
-    /// - `tls.privateKey` (string): TLS private key, in PEM format for NIOSSL, or as a file path to a `.p12` file for NIOTransportServices.
-    /// - `tls.privateKeyPassword` (string): Password for the TLS private key. Only applicable for NIOTransportServices.
-    /// - `tls.trustRoots` (string, optional): TLS trust roots, in PEM format for NIOSSL, or as a file path to a `.der` file for NIOTransportServices.
-    /// - `tls.serverName` (string, optional): Optional server name for SNI (Server Name Indication).
+    /// - `tls.privateKey` (string): TLS private key, in PEM format for NIOSSL.
+    /// - `tls.trustRoots` (string, optional): TLS trust roots, in PEM format for NIOSSL.
+    /// ### WebSocket specific configuration keys
     /// - `webSocket.urlPath` (string, optional): The URL path to use when establishing the WebSocket connection.
     /// - `webSocket.maxFrameSize` (int, optional): The maximum frame size for the WebSocket connection.
     /// - `webSocket.initialRequestHeaders` (string array, optional): Initial HTTP headers to include in the WebSocket handshake request.
@@ -135,56 +140,69 @@ extension MQTTConnectionConfiguration.PingConfiguration {
     }
 }
 
-extension MQTTConnectionConfiguration.TLS {
-    enum TLSConfigError: Error {
-        case incompatibleConfiguration
-    }
-
-    /// Creates a new TLS configuration using values from the provided reader.
+#if canImport(Network)
+extension TSTLSConfiguration {
+    /// Creates a new TLS configuration for NIO Transport Services using values from the provided reader.
     ///
     /// ## Configuration keys
-    /// - `config` (string, optional): Whether to use `NIOSSL` or `NIOTransportServices`.
-    /// - `certificateChain` (string): TLS certificate chain in PEM format. Only applicable for `NIOSSL`.
-    /// - `privateKey` (string): TLS private key, in PEM format for NIOSSL, or as a file path to a `.p12` file for NIOTransportServices.
-    /// - `privateKeyPassword` (string): Password for the TLS private key. Only applicable for NIOTransportServices.
-    /// - `trustRoots` (string, optional): TLS trust roots, in PEM format for NIOSSL, or as a file path to a `.der` file for NIOTransportServices.
-    /// - `serverName` (string, optional): Optional server name for SNI (Server Name Indication).
+    /// - `privateKey` (string): TLS private key, as a file path to a `.p12` file.
+    /// - `privateKeyPassword` (string): Password for the TLS private key.
+    /// - `trustRoots` (string): TLS trust roots, as a file path to a `.der` file.
     ///
     /// - Parameter config: The config reader to read configuration values from.
-    ///
-    /// - Throws: ``MQTTConnectionConfiguration/TLS/TLSConfigError/incompatibleConfiguration`` if the configuration is not valid or not supported.
     init(config: ConfigReader) throws {
-        let privateKey = try config.requiredString(forKey: "privateKey")
-        let trustRoots = config.string(forKey: "trustRoots")
-        let tlsServerName = config.string(forKey: "serverName")
-        switch config.string(forKey: "config")?.lowercased() {
-        #if os(macOS) || os(Linux) || os(Android)
-        case "niossl":
-            let certificateChainPEM = try config.requiredString(forKey: "certificateChain")
-            let certificateChain = try NIOSSLCertificate.fromPEMBytes([UInt8](certificateChainPEM.utf8))
-            let privateKey = try NIOSSLPrivateKey(bytes: [UInt8](privateKey.utf8), format: .pem)
-            let trustRoots = try trustRoots.map { try NIOSSLCertificate.fromPEMBytes([UInt8]($0.utf8)) }
-            var tlsConfiguration = TLSConfiguration.makeServerConfiguration(
-                certificateChain: certificateChain.map { .certificate($0) },
-                privateKey: .privateKey(privateKey)
-            )
-            tlsConfiguration.trustRoots = trustRoots.map { .certificates($0) }
-            self.base = .enable(.niossl(tlsConfiguration), tlsServerName: tlsServerName)
-        #endif
-        #if canImport(Network)
-        case "ts", "niots", "niotransportservices":
-            let privateKeyConfig = try TSTLSConfiguration.Identity.p12(
-                filename: privateKey,
+        try self.init(
+            trustRoots: .der(config.requiredString(forKey: "trustRoots")),
+            clientIdentity: .p12(
+                filename: config.requiredString(forKey: "privateKey"),
                 password: config.requiredString(forKey: "privateKeyPassword", isSecret: true)
             )
-            guard let trustRoots else { throw TLSConfigError.incompatibleConfiguration }
-            let trustRootsConfig = try TSTLSConfiguration.Certificates.der(trustRoots)
-            let tlsConfiguration = TSTLSConfiguration(trustRoots: trustRootsConfig, clientIdentity: privateKeyConfig)
-            self.base = .enable(.ts(tlsConfiguration), tlsServerName: tlsServerName)
-        #endif
-        default:
-            throw TLSConfigError.incompatibleConfiguration
+        )
+    }
+}
+#endif
+
+extension MQTTConnectionConfiguration.TLS {
+    /// Creates a new TLS configuration using values from the provided reader.
+    ///
+    /// If the `niots` scoped configuration is present, and NIOTransportServices is available, it will be used as it takes precedence over the `NIOSSL` configuration.
+    /// Otherwise, the `NIOSSL` configuration will be used.
+    ///
+    /// ## Configuration keys
+    /// - `serverName` (string, optional): Optional server name for SNI (Server Name Indication). Valid for both `NIOSSL` and `NIOTransportServices`.
+    /// ### NIOTransportServices specific configuration keys
+    /// - `niots.privateKey` (string): TLS private key as a file path to a `.p12` file for NIOTransportServices.
+    /// - `niots.privateKeyPassword` (string): Password for the TLS private key. Only applicable for NIOTransportServices.
+    /// - `niots.trustRoots` (string, optional): TLS trust roots as a file path to a `.der` file for NIOTransportServices.
+    /// ### NIOSSL specific configuration keys (used as fallback)
+    /// - `certificateChain` (string): TLS certificate chain in PEM format. Only applicable for `NIOSSL`.
+    /// - `privateKey` (string): TLS private key, in PEM format for NIOSSL.
+    /// - `trustRoots` (string, optional): TLS trust roots, in PEM format for NIOSSL.
+    ///
+    /// - Parameter config: The config reader to read configuration values from.
+    init(config: ConfigReader) throws {
+        let tlsServerName = config.string(forKey: "serverName")
+        #if canImport(Network)
+        let nioTSConfigReader = config.scoped(to: "niots")
+        if let tsTLSConfiguration = try? TSTLSConfiguration(config: nioTSConfigReader) {
+            self.base = .enable(.ts(tsTLSConfiguration), tlsServerName: tlsServerName ?? nioTSConfigReader.string(forKey: "serverName"))
+            return
         }
+        #endif
+        #if os(macOS) || os(Linux) || os(Android)
+        let privateKey = try config.requiredString(forKey: "privateKey")
+        let trustRoots = config.string(forKey: "trustRoots")
+        let certificateChainPEM = try config.requiredString(forKey: "certificateChain")
+        let certificateChain = try NIOSSLCertificate.fromPEMBytes([UInt8](certificateChainPEM.utf8))
+        let nioSSLPrivateKey = try NIOSSLPrivateKey(bytes: [UInt8](privateKey.utf8), format: .pem)
+        let nioSSLTrustRoots = try trustRoots.map { try NIOSSLCertificate.fromPEMBytes([UInt8]($0.utf8)) }
+        var tlsConfiguration = TLSConfiguration.makeServerConfiguration(
+            certificateChain: certificateChain.map { .certificate($0) },
+            privateKey: .privateKey(nioSSLPrivateKey)
+        )
+        tlsConfiguration.trustRoots = nioSSLTrustRoots.map { .certificates($0) }
+        self.base = .enable(.niossl(tlsConfiguration), tlsServerName: tlsServerName)
+        #endif
     }
 }
 

--- a/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
@@ -48,11 +48,12 @@ extension MQTTConnectionConfiguration {
     ///
     /// - Parameter config: The config reader to read configuration values from.
     public init(config: ConfigReader) {
+        let willConfig = config.scoped(to: "will")
         switch config.string(forKey: "version") {
         case "v5_0", "v5", "5_0", "5", "v5.0", "5.0":
-            self.versionConfiguration = .v5_0(will: try? .init(config: config))
+            self.versionConfiguration = .v5_0(will: try? .init(config: willConfig))
         case .none, .some:
-            self.versionConfiguration = .v3_1_1(will: try? .init(config: config))
+            self.versionConfiguration = .v3_1_1(will: try? .init(config: willConfig))
         }
         self.keepAliveInterval = config.int(forKey: "keepAliveInterval", as: Duration.self, default: .seconds(90))
         self.pingConfiguration = .init(config: config)
@@ -60,8 +61,8 @@ extension MQTTConnectionConfiguration {
         self.timeout = config.int(forKey: "timeout", as: Duration.self)
         self.userName = config.string(forKey: "userName")
         self.password = config.string(forKey: "password", isSecret: true)
-        self.tls = (try? .init(config: config)) ?? .disable
-        self.webSocketConfiguration = .init(config: config)
+        self.tls = (try? .init(config: config.scoped(to: "tls"))) ?? .disable
+        self.webSocketConfiguration = .init(config: config.scoped(to: "webSocket"))
     }
 }
 
@@ -74,19 +75,18 @@ extension MQTTConnectionConfiguration.VersionConfiguration.WillMessageV311 {
     /// Creates a new Will Message for MQTT v3.1.1 using values from the provided reader.
     ///
     /// ## Configuration keys
-    /// - `will.topicName` (string): Topic Name of the Will Message.
-    /// - `will.payload` (bytes): Payload of the Will Message.
-    /// - `will.qos` (int): QoS level of the Will Message.
-    /// - `will.retain` (bool, optional, default: `false`): Specifies if the Will Message is to be retained when it is published.
+    /// - `topicName` (string): Topic Name of the Will Message.
+    /// - `payload` (bytes): Payload of the Will Message.
+    /// - `qos` (int): QoS level of the Will Message.
+    /// - `retain` (bool, optional, default: `false`): Specifies if the Will Message is to be retained when it is published.
     ///
     /// - Parameter config: The config reader to read configuration values from.
     init(config: ConfigReader) throws {
-        let willConfig = config.scoped(to: "will")
         self.init(
-            topicName: try willConfig.requiredString(forKey: "topicName"),
-            payload: .init(bytes: try willConfig.requiredBytes(forKey: "payload")),
-            qos: try willConfig.requiredInt(forKey: "qos", as: MQTTQoS.self),
-            retain: willConfig.bool(forKey: "retain", default: false)
+            topicName: try config.requiredString(forKey: "topicName"),
+            payload: .init(bytes: try config.requiredBytes(forKey: "payload")),
+            qos: try config.requiredInt(forKey: "qos", as: MQTTQoS.self),
+            retain: config.bool(forKey: "retain", default: false)
         )
     }
 }
@@ -95,19 +95,18 @@ extension MQTTConnectionConfiguration.VersionConfiguration.WillMessageV5 {
     /// Creates a new Will Message for MQTT v5.0 using values from the provided reader.
     ///
     /// ## Configuration keys
-    /// - `will.topicName` (string): Topic Name of the Will Message.
-    /// - `will.payload` (bytes): Payload of the Will Message.
-    /// - `will.qos` (int): QoS level of the Will Message.
-    /// - `will.retain` (bool, optional, default: `false`): Specifies if the Will Message is to be retained when it is published.
+    /// - `topicName` (string): Topic Name of the Will Message.
+    /// - `payload` (bytes): Payload of the Will Message.
+    /// - `qos` (int): QoS level of the Will Message.
+    /// - `retain` (bool, optional, default: `false`): Specifies if the Will Message is to be retained when it is published.
     ///
     /// - Parameter config: The config reader to read configuration values from.
     init(config: ConfigReader) throws {
-        let willConfig = config.scoped(to: "will")
         self.init(
-            topicName: try willConfig.requiredString(forKey: "topicName"),
-            payload: .init(bytes: try willConfig.requiredBytes(forKey: "payload")),
-            qos: try willConfig.requiredInt(forKey: "qos", as: MQTTQoS.self),
-            retain: willConfig.bool(forKey: "retain", default: false)
+            topicName: try config.requiredString(forKey: "topicName"),
+            payload: .init(bytes: try config.requiredBytes(forKey: "payload")),
+            qos: try config.requiredInt(forKey: "qos", as: MQTTQoS.self),
+            retain: config.bool(forKey: "retain", default: false)
         )
     }
 }
@@ -144,25 +143,24 @@ extension MQTTConnectionConfiguration.TLS {
     /// Creates a new TLS configuration using values from the provided reader.
     ///
     /// ## Configuration keys
-    /// - `tls.config` (string, optional): Whether to use `NIOSSL` or `NIOTransportServices`.
-    /// - `tls.certificateChain` (string): TLS certificate chain in PEM format. Only applicable for `NIOSSL`.
-    /// - `tls.privateKey` (string): TLS private key, in PEM format for NIOSSL, or as a file path to a `.p12` file for NIOTransportServices.
-    /// - `tls.privateKeyPassword` (string): Password for the TLS private key. Only applicable for NIOTransportServices.
-    /// - `tls.trustRoots` (string, optional): TLS trust roots, in PEM format for NIOSSL, or as a file path to a `.der` file for NIOTransportServices.
-    /// - `tls.serverName` (string, optional): Optional server name for SNI (Server Name Indication).
+    /// - `config` (string, optional): Whether to use `NIOSSL` or `NIOTransportServices`.
+    /// - `certificateChain` (string): TLS certificate chain in PEM format. Only applicable for `NIOSSL`.
+    /// - `privateKey` (string): TLS private key, in PEM format for NIOSSL, or as a file path to a `.p12` file for NIOTransportServices.
+    /// - `privateKeyPassword` (string): Password for the TLS private key. Only applicable for NIOTransportServices.
+    /// - `trustRoots` (string, optional): TLS trust roots, in PEM format for NIOSSL, or as a file path to a `.der` file for NIOTransportServices.
+    /// - `serverName` (string, optional): Optional server name for SNI (Server Name Indication).
     ///
     /// - Parameter config: The config reader to read configuration values from.
     ///
     /// - Throws: ``MQTTConnectionConfiguration/TLS/TLSConfigError/incompatibleConfiguration`` if the configuration is not valid or not supported.
     init(config: ConfigReader) throws {
-        let tlsConfig = config.scoped(to: "tls")
-        let privateKey = try tlsConfig.requiredString(forKey: "privateKey")
-        let trustRoots = tlsConfig.string(forKey: "trustRoots")
-        let tlsServerName = tlsConfig.string(forKey: "serverName")
-        switch tlsConfig.string(forKey: "config")?.lowercased() {
+        let privateKey = try config.requiredString(forKey: "privateKey")
+        let trustRoots = config.string(forKey: "trustRoots")
+        let tlsServerName = config.string(forKey: "serverName")
+        switch config.string(forKey: "config")?.lowercased() {
         #if os(macOS) || os(Linux) || os(Android)
         case "niossl":
-            let certificateChainPEM = try tlsConfig.requiredString(forKey: "certificateChain")
+            let certificateChainPEM = try config.requiredString(forKey: "certificateChain")
             let certificateChain = try NIOSSLCertificate.fromPEMBytes([UInt8](certificateChainPEM.utf8))
             let privateKey = try NIOSSLPrivateKey(bytes: [UInt8](privateKey.utf8), format: .pem)
             let trustRoots = try trustRoots.map { try NIOSSLCertificate.fromPEMBytes([UInt8]($0.utf8)) }
@@ -177,7 +175,7 @@ extension MQTTConnectionConfiguration.TLS {
         case "ts", "niots", "niotransportservices":
             let privateKeyConfig = try TSTLSConfiguration.Identity.p12(
                 filename: privateKey,
-                password: tlsConfig.requiredString(forKey: "privateKeyPassword", isSecret: true)
+                password: config.requiredString(forKey: "privateKeyPassword", isSecret: true)
             )
             guard let trustRoots else { throw TLSConfigError.incompatibleConfiguration }
             let trustRootsConfig = try TSTLSConfiguration.Certificates.der(trustRoots)
@@ -219,17 +217,16 @@ extension MQTTConnectionConfiguration.WebSocketConfiguration {
     /// Creates a new WebSocket configuration using values from the provided reader.
     ///
     /// ## Configuration keys
-    /// - `webSocket.urlPath` (string, optional): The URL path to use when establishing the WebSocket connection.
-    /// - `webSocket.maxFrameSize` (int, optional): The maximum frame size for the WebSocket connection.
-    /// - `webSocket.initialRequestHeaders` (string array, optional): Initial HTTP headers to include in the WebSocket handshake request.
+    /// - `urlPath` (string, optional): The URL path to use when establishing the WebSocket connection.
+    /// - `maxFrameSize` (int, optional): The maximum frame size for the WebSocket connection.
+    /// - `initialRequestHeaders` (string array, optional): Initial HTTP headers to include in the WebSocket handshake request.
     ///
     /// - Parameter config: The config reader to read configuration values from.
     init?(config: ConfigReader) {
-        let webSocketConfig = config.scoped(to: "webSocket")
-        let urlPath = webSocketConfig.string(forKey: "urlPath")
-        let maxFrameSize = webSocketConfig.int(forKey: "maxFrameSize")
+        let urlPath = config.string(forKey: "urlPath")
+        let maxFrameSize = config.int(forKey: "maxFrameSize")
         let initialRequestHeaders: HTTPFields?
-        if let initialRequestHeadersArray = webSocketConfig.stringArray(forKey: "initialRequestHeaders", as: ConfigHTTPField.self) {
+        if let initialRequestHeadersArray = config.stringArray(forKey: "initialRequestHeaders", as: ConfigHTTPField.self) {
             var headers = HTTPFields()
             for header in initialRequestHeadersArray {
                 headers.append(.init(name: header.name, value: header.value))

--- a/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
@@ -196,7 +196,8 @@ extension MQTTConnectionConfiguration.TLS {
             self.base = .enable(.ts(tsTLSConfiguration), tlsServerName: tlsServerName ?? nioTSConfigReader.string(forKey: "serverName"))
             return
         }
-        #elseif os(macOS) || os(Linux) || os(Android)
+        #endif
+        #if os(macOS) || os(Linux) || os(Android)
         let privateKey = try config.requiredString(forKey: "privateKey")
         let trustRoots = config.string(forKey: "trustRoots")
         let certificateChainPEM = try config.requiredString(forKey: "certificateChain")

--- a/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
@@ -218,12 +218,10 @@ extension MQTTConnectionConfiguration.TLS {
 }
 
 struct ConfigHTTPField: ExpressibleByConfigString {
-    let name: HTTPField.Name
-    let value: String
+    let field: HTTPField
 
-    init(name: HTTPField.Name, value: String) {
-        self.name = name
-        self.value = value
+    init(field: HTTPField) {
+        self.field = field
     }
 
     /// Creates a HTTP header from a configuration string.
@@ -236,10 +234,10 @@ struct ConfigHTTPField: ExpressibleByConfigString {
         guard let name = HTTPField.Name(String(configString[..<colonIndex].trimmingWhitespace())) else { return nil }
         let valueStartIndex = configString.index(after: colonIndex)
         let value = String(configString[valueStartIndex...].trimmingWhitespace())
-        self.init(name: name, value: value)
+        self.init(field: HTTPField(name: name, value: value))
     }
 
-    var description: String { "\(name):\(value)" }
+    var description: String { "\(field.name):\(field.value)" }
 }
 
 extension MQTTConnectionConfiguration.WebSocketConfiguration {
@@ -254,16 +252,12 @@ extension MQTTConnectionConfiguration.WebSocketConfiguration {
     init?(config: ConfigReader) {
         let urlPath = config.string(forKey: "urlPath")
         let maxFrameSize = config.int(forKey: "maxFrameSize")
-        let initialRequestHeaders: HTTPFields?
-        if let initialRequestHeadersArray = config.stringArray(forKey: "initialRequestHeaders", as: ConfigHTTPField.self) {
-            var headers = HTTPFields()
-            for header in initialRequestHeadersArray {
-                headers.append(.init(name: header.name, value: header.value))
+        let initialRequestHeaders: HTTPFields? =
+            if let initialRequestHeadersArray = config.stringArray(forKey: "initialRequestHeaders", as: ConfigHTTPField.self) {
+                HTTPFields(initialRequestHeadersArray.lazy.map { $0.field })
+            } else {
+                nil
             }
-            initialRequestHeaders = headers
-        } else {
-            initialRequestHeaders = nil
-        }
 
         if urlPath != nil || maxFrameSize != nil || initialRequestHeaders != nil {
             self.init(

--- a/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration.swift
@@ -156,27 +156,6 @@ public struct MQTTConnectionConfiguration: Sendable {
         }
     }
 
-    /// Authentication credentials for accessing an MQTT server.
-    ///
-    /// Use this structure to provide user ID and password credentials
-    /// when the server requires authentication for access.
-    public struct Authentication: Sendable {
-        /// The user identifier used to authenticate against a secured MQTT server.
-        public var userName: String
-        /// The password used to authenticate against a secured MQTT server.
-        public var password: String?
-
-        /// Creates a new authentication configuration.
-        ///
-        /// - Parameters:
-        ///   - userName: The user identifier used to authenticate against a secured MQTT server.
-        ///   - password: The password used to authenticate against a secured MQTT server.
-        public init(userName: String, password: String?) {
-            self.userName = userName
-            self.password = password
-        }
-    }
-
     /// Configuration for WebSocket connection.
     public struct WebSocketConfiguration: Sendable {
         /// Creates a WebSocket configuration.
@@ -235,10 +214,13 @@ public struct MQTTConnectionConfiguration: Sendable {
     public var connectTimeout: Duration
     /// Timeout for server response.
     public var timeout: Duration?
-    /// Optional authentication credentials for accessing the MQTT server.
+    /// The user identifier used to authenticate against a secured MQTT server.
+    public var userName: String?
+    /// The password used to authenticate against a secured MQTT server.
     ///
-    /// Set this property when connecting to a server that requires authentication.
-    public var authentication: Authentication?
+    /// > Note: When using MQTT v3.1.1, if you provide a Password you must also provide a User Name.
+    /// MQTT v5.0 allows the sending of a Password with no User Name.
+    public var password: String?
     /// TLS configuration for the connection.
     ///
     /// Use `.disable` for unencrypted connections or `.enable(...)` for secure connections.
@@ -254,7 +236,8 @@ public struct MQTTConnectionConfiguration: Sendable {
     ///   - pingConfiguration: Configuration for sending `PINGREQ` messages.
     ///   - connectTimeout: Timeout for connecting to server.
     ///   - timeout: Timeout for server ACK responses.
-    ///   - authentication: Optional credentials for accessing the MQTT server. Set to `nil` for unauthenticated access.
+    ///   - userName: The user identifier used to authenticate against a secured MQTT server.
+    ///   - password: The password used to authenticate against a secured MQTT server.
     ///   - tls: TLS configuration for secure connections. Defaults to `.disable` for unencrypted connections.
     ///   - webSocketConfiguration: Configuration to set if using a WebSocket connection.
     public init(
@@ -263,7 +246,8 @@ public struct MQTTConnectionConfiguration: Sendable {
         pingConfiguration: PingConfiguration = .useServerKeepAlive,
         connectTimeout: Duration = .seconds(10),
         timeout: Duration? = nil,
-        authentication: Authentication? = nil,
+        userName: String? = nil,
+        password: String? = nil,
         tls: TLS = .disable,
         webSocketConfiguration: WebSocketConfiguration? = nil
     ) {
@@ -272,7 +256,8 @@ public struct MQTTConnectionConfiguration: Sendable {
         self.pingConfiguration = pingConfiguration
         self.connectTimeout = connectTimeout
         self.timeout = timeout
-        self.authentication = authentication
+        self.userName = userName
+        self.password = password
         self.tls = tls
         self.webSocketConfiguration = webSocketConfiguration
     }

--- a/Sources/MQTTNIO/Utils/StringProtocol+trimmingWhitespace.swift
+++ b/Sources/MQTTNIO/Utils/StringProtocol+trimmingWhitespace.swift
@@ -1,0 +1,43 @@
+//
+// This source file is part of the MQTTNIO project
+// Copyright (c) 2020-2026 the MQTTNIO authors
+//
+// See LICENSE for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+extension StringProtocol {
+    func trimmingWhitespace() -> Self.SubSequence {
+        self.trimmingWhitespacePrefix().trimmingWhitespaceSuffix()
+    }
+
+    func endOfWhitespacePrefix() -> Self.Index {
+        var index = self.startIndex
+        while index < self.endIndex, self[index].isWhitespace {
+            formIndex(after: &index)
+        }
+        return index
+    }
+
+    func trimmingWhitespacePrefix() -> Self.SubSequence {
+        let start = self.endOfWhitespacePrefix()
+        return self[start..<self.endIndex]
+    }
+
+    func startOfWhitespaceSuffix() -> Self.Index {
+        var index = self.endIndex
+        while index > self.startIndex {
+            let after = index
+            formIndex(before: &index)
+            if !self[index].isWhitespace {
+                return after
+            }
+        }
+        return index
+    }
+
+    func trimmingWhitespaceSuffix() -> Self.SubSequence {
+        let end = self.startOfWhitespaceSuffix()
+        return self[self.startIndex..<end]
+    }
+}

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -219,11 +219,10 @@ struct IntegrationTests {
             let configReader = ConfigReader(
                 provider: InMemoryProvider(
                     values: [
-                        "tls.config": "niots",
-                        "tls.trustRoots": .init(stringLiteral: "\(Self.rootPath)/mosquitto/certs/ca.der"),
-                        "tls.privateKey": .init(stringLiteral: "\(Self.rootPath)/mosquitto/certs/client.p12"),
-                        "tls.privateKeyPassword": "MQTTNIOClientCertPassword",
-                        "tls.serverName": "soto.codes",
+                        "tls.niots.trustRoots": .init(stringLiteral: "\(Self.rootPath)/mosquitto/certs/ca.der"),
+                        "tls.niots.privateKey": .init(stringLiteral: "\(Self.rootPath)/mosquitto/certs/client.p12"),
+                        "tls.niots.privateKeyPassword": "MQTTNIOClientCertPassword",
+                        "tls.niots.serverName": "soto.codes",
                     ]
                 )
             )

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -104,7 +104,7 @@ struct IntegrationTests {
     func connectWithUsernameAndPassword() async throws {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname, port: 1884),
-            configuration: .init(authentication: .init(userName: "mqttnio", password: "mqttnio-password")),
+            configuration: .init(userName: "mqttnio", password: "mqttnio-password"),
             identifier: "connectWithUsernameAndPassword",
             logger: Logger(label: #function).withLogLevel(.trace)
         ) { connection in
@@ -117,7 +117,7 @@ struct IntegrationTests {
         await #expect(throws: MQTTError.connectionError(.notAuthorized)) {
             try await MQTTConnection.withConnection(
                 address: .hostname(Self.hostname, port: 1884),
-                configuration: .init(authentication: .init(userName: "wrong", password: "wrong")),
+                configuration: .init(userName: "wrong", password: "wrong"),
                 identifier: "connectWithWrongUsernameAndPassword",
                 logger: Logger(label: #function).withLogLevel(.trace)
             ) { connection in

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import Configuration
 import Foundation
 import InMemoryLogging
 import Logging
@@ -206,6 +207,30 @@ struct IntegrationTests {
                     )
                 ),
                 identifier: "tlsConnectFromP12",
+                eventLoop: Self.eventLoopGroupSingleton.any(),
+                logger: Logger(label: #function).withLogLevel(.trace)
+            ) { connection in
+                try await connection.ping()
+            }
+        }
+
+        @Test("Connect with NIOTransportServices from ConfigReader")
+        func tlsConnectWithConfigReader() async throws {
+            let configReader = ConfigReader(
+                provider: InMemoryProvider(
+                    values: [
+                        "tls.config": "niots",
+                        "tls.trustRoots": .init(stringLiteral: "\(Self.rootPath)/mosquitto/certs/ca.der"),
+                        "tls.privateKey": .init(stringLiteral: "\(Self.rootPath)/mosquitto/certs/client.p12"),
+                        "tls.privateKeyPassword": "MQTTNIOClientCertPassword",
+                        "tls.serverName": "soto.codes",
+                    ]
+                )
+            )
+            try await MQTTConnection.withConnection(
+                address: .hostname(Self.hostname, port: 8883),
+                configuration: .init(config: configReader),
+                identifier: "tlsConnectWithConfigReader",
                 eventLoop: Self.eventLoopGroupSingleton.any(),
                 logger: Logger(label: #function).withLogLevel(.trace)
             ) { connection in

--- a/Tests/MQTTNIOTests/ConfigurationTests.swift
+++ b/Tests/MQTTNIOTests/ConfigurationTests.swift
@@ -192,8 +192,8 @@ struct ConfigurationTests {
         )
         let initialRequestHeaders = configReader.stringArray(forKey: "initialRequestHeaders", as: ConfigHTTPField.self)
         #expect(initialRequestHeaders?.count == 2)
-        #expect(initialRequestHeaders?[0].name == HTTPField.Name("X-Custom-Header"))
-        #expect(initialRequestHeaders?[0].value == "CustomValue")
+        #expect(initialRequestHeaders?[0].field.name == HTTPField.Name("X-Custom-Header"))
+        #expect(initialRequestHeaders?[0].field.value == "CustomValue")
     }
 
     let caCertificateData =

--- a/Tests/MQTTNIOTests/ConfigurationTests.swift
+++ b/Tests/MQTTNIOTests/ConfigurationTests.swift
@@ -42,10 +42,13 @@ struct ConfigurationTests {
                     "tls.serverName": "example.com",
                     "webSocket.urlPath": "/test",
                     "webSocket.maxFrameSize": 21,
-                    "webSocket.initialRequestHeaders": .init(.stringArray([
-                        "X-Custom-Header: CustomValue",
-                        "X-Another-Header: AnotherValue",
-                    ]), isSecret: false),
+                    "webSocket.initialRequestHeaders": .init(
+                        .stringArray([
+                            "X-Custom-Header: CustomValue",
+                            "X-Another-Header: AnotherValue",
+                        ]),
+                        isSecret: false
+                    ),
                 ]
             )
         )

--- a/Tests/MQTTNIOTests/ConfigurationTests.swift
+++ b/Tests/MQTTNIOTests/ConfigurationTests.swift
@@ -99,10 +99,10 @@ struct ConfigurationTests {
         let configReader = ConfigReader(
             provider: InMemoryProvider(
                 values: [
-                    "will.topicName": "test/topic",
-                    "will.payload": .init(.bytes([0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x2C, 0x20, 0x57, 0x6F, 0x72, 0x6C, 0x64, 0x21]), isSecret: false),
-                    "will.qos": 2,
-                    "will.retain": true,
+                    "topicName": "test/topic",
+                    "payload": .init(.bytes([0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x2C, 0x20, 0x57, 0x6F, 0x72, 0x6C, 0x64, 0x21]), isSecret: false),
+                    "qos": 2,
+                    "retain": true,
                 ]
             )
         )
@@ -154,11 +154,11 @@ struct ConfigurationTests {
         let configReader = ConfigReader(
             providers: [
                 InMemoryProvider(values: [
-                    "tls.config": "niossl",
-                    "tls.certificateChain": .init(stringLiteral: serverCertificateData),
-                    "tls.privateKey": .init(stringLiteral: serverPrivateKeyData),
-                    "tls.trustRoots": .init(stringLiteral: caCertificateData),
-                    "tls.serverName": "example.com",
+                    "config": "niossl",
+                    "certificateChain": .init(stringLiteral: serverCertificateData),
+                    "privateKey": .init(stringLiteral: serverPrivateKeyData),
+                    "trustRoots": .init(stringLiteral: caCertificateData),
+                    "serverName": "example.com",
                 ])
             ]
         )

--- a/Tests/MQTTNIOTests/ConfigurationTests.swift
+++ b/Tests/MQTTNIOTests/ConfigurationTests.swift
@@ -1,0 +1,292 @@
+//
+// This source file is part of the MQTTNIO project
+// Copyright (c) 2020-2026 the MQTTNIO authors
+//
+// See LICENSE for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Configuration
+import HTTPTypes
+import NIOCore
+import Testing
+
+@testable import MQTTNIO
+
+#if os(macOS) || os(Linux) || os(Android)
+import NIOSSL
+#endif
+
+@Suite("Configuration Tests")
+struct ConfigurationTests {
+    @Test("MQTTConnectionConfiguration+ConfigReader")
+    func connectionConfiguration() throws {
+        let configReader = ConfigReader(
+            provider: InMemoryProvider(
+                values: [
+                    "version": "3",
+                    "will.topicName": "test/topic",
+                    "will.payload": .init(.bytes([0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x2C, 0x20, 0x57, 0x6F, 0x72, 0x6C, 0x64, 0x21]), isSecret: false),
+                    "will.qos": 2,
+                    "will.retain": true,
+                    "keepAliveInterval": 30,
+                    "ping": 10,
+                    "connectTimeout": 20,
+                    "timeout": 20,
+                    "userName": "mqtt_user",
+                    "password": .init(.string("mqtt_password"), isSecret: true),
+                    "tls.config": "niossl",
+                    "tls.certificateChain": .init(stringLiteral: serverCertificateData),
+                    "tls.privateKey": .init(stringLiteral: serverPrivateKeyData),
+                    "tls.trustRoots": .init(stringLiteral: caCertificateData),
+                    "tls.serverName": "example.com",
+                    "webSocket.urlPath": "/test",
+                    "webSocket.maxFrameSize": 21,
+                    "webSocket.initialRequestHeaders": .init(.stringArray([
+                        "X-Custom-Header: CustomValue",
+                        "X-Another-Header: AnotherValue",
+                    ]), isSecret: false),
+                ]
+            )
+        )
+
+        let config = MQTTConnectionConfiguration(config: configReader)
+        guard case .v3_1_1(let willMessage) = config.versionConfiguration, let willMessage else {
+            Issue.record("Expected MQTT version to be 3.1.1")
+            return
+        }
+        #expect(willMessage.topicName == "test/topic")
+        #expect(willMessage.payload == ByteBuffer(string: "Hello, World!"))
+        #expect(willMessage.qos == .exactlyOnce)
+        #expect(willMessage.retain)
+        #expect(config.keepAliveInterval == .seconds(30))
+        guard case .pingInterval(let interval) = config.pingConfiguration.base else {
+            Issue.record("Expected ping configuration to be a ping interval")
+            return
+        }
+        #expect(interval == .seconds(10))
+        #expect(config.connectTimeout == .seconds(20))
+        #expect(config.timeout == .seconds(20))
+        #expect(config.userName == "mqtt_user")
+        #expect(config.password == "mqtt_password")
+        let serverTLSConfiguration = try getServerTLSConfiguration()
+        guard case .enable(let tlsConfig, let tlsServerName) = config.tls.base,
+            case .niossl(let tlsConfiguration) = tlsConfig,
+            tlsServerName == "example.com"
+        else {
+            Issue.record("Expected TLS to be enabled with NIOSSL configuration")
+            return
+        }
+        #expect(tlsConfiguration.certificateChain == serverTLSConfiguration.certificateChain)
+        #expect(tlsConfiguration.privateKey == serverTLSConfiguration.privateKey)
+        #expect(tlsConfiguration.trustRoots == serverTLSConfiguration.trustRoots)
+        #expect(config.webSocketConfiguration?.urlPath == "/test")
+        #expect(config.webSocketConfiguration?.maxFrameSize == 21)
+        #expect(config.webSocketConfiguration?.initialRequestHeaders.count == 2)
+    }
+
+    @Test("MQTTQoS+ExpressibleByConfigInt", arguments: MQTTQoS.allCases)
+    func qosConfigInt(qos: MQTTQoS) {
+        #expect(MQTTQoS(configInt: Int(qos.rawValue)) == qos)
+        #expect(qos.configInt == qos.rawValue)
+    }
+
+    @Test("Will Message")
+    func willMessage() throws {
+        let configReader = ConfigReader(
+            provider: InMemoryProvider(
+                values: [
+                    "will.topicName": "test/topic",
+                    "will.payload": .init(.bytes([0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x2C, 0x20, 0x57, 0x6F, 0x72, 0x6C, 0x64, 0x21]), isSecret: false),
+                    "will.qos": 2,
+                    "will.retain": true,
+                ]
+            )
+        )
+
+        let v3Will = try MQTTConnectionConfiguration.VersionConfiguration.WillMessageV311(config: configReader)
+        #expect(v3Will.topicName == "test/topic")
+        #expect(v3Will.payload == ByteBuffer(string: "Hello, World!"))
+        #expect(v3Will.qos == .exactlyOnce)
+        #expect(v3Will.retain)
+
+        let v5Will = try MQTTConnectionConfiguration.VersionConfiguration.WillMessageV5(config: configReader)
+        #expect(v5Will.topicName == "test/topic")
+        #expect(v5Will.payload == ByteBuffer(string: "Hello, World!"))
+        #expect(v5Will.qos == .exactlyOnce)
+        #expect(v5Will.retain)
+    }
+
+    @Test("Ping Configuration", arguments: [ConfigValue(.string("disable"), isSecret: false), "useServerKeepAlive", 21, "invalid"])
+    func pingConfiguration(value: ConfigValue) {
+        let configReader = ConfigReader(provider: InMemoryProvider(values: ["ping": value]))
+        let pingConfiguration = MQTTConnectionConfiguration.PingConfiguration(config: configReader)
+        switch (value.content, pingConfiguration.base) {
+        case (.int(let seconds), .pingInterval(let duration)):
+            #expect(duration == .seconds(seconds))
+        case (.string(let string), .disable):
+            #expect(string == "disable")
+        case (.string, .useServerKeepAlive):
+            // With invalid strings it defaults to `useServerKeepAlive`
+            break
+        default:
+            Issue.record("Invalid combination of ConfigValue and PingConfiguration")
+        }
+    }
+
+    @Test("TLS with NIOSSL")
+    func tlsNIOSSL() throws {
+        func getServerTLSConfiguration() throws -> TLSConfiguration {
+            let caCertificate = try NIOSSLCertificate(bytes: [UInt8](caCertificateData.utf8), format: .pem)
+            let certificate = try NIOSSLCertificate(bytes: [UInt8](serverCertificateData.utf8), format: .pem)
+            let privateKey = try NIOSSLPrivateKey(bytes: [UInt8](serverPrivateKeyData.utf8), format: .pem)
+            var tlsConfig = TLSConfiguration.makeServerConfiguration(
+                certificateChain: [.certificate(certificate)],
+                privateKey: .privateKey(privateKey)
+            )
+            tlsConfig.trustRoots = .certificates([caCertificate])
+            return tlsConfig
+        }
+
+        let configReader = ConfigReader(
+            providers: [
+                InMemoryProvider(values: [
+                    "tls.config": "niossl",
+                    "tls.certificateChain": .init(stringLiteral: serverCertificateData),
+                    "tls.privateKey": .init(stringLiteral: serverPrivateKeyData),
+                    "tls.trustRoots": .init(stringLiteral: caCertificateData),
+                    "tls.serverName": "example.com",
+                ])
+            ]
+        )
+
+        let tls = try MQTTConnectionConfiguration.TLS(config: configReader)
+        let serverTLSConfiguration = try getServerTLSConfiguration()
+        guard case .enable(let config, let tlsServerName) = tls.base,
+            case .niossl(let tlsConfiguration) = config,
+            tlsServerName == "example.com"
+        else {
+            Issue.record("Expected TLS to be enabled with NIOSSL configuration")
+            return
+        }
+        #expect(tlsConfiguration.certificateChain == serverTLSConfiguration.certificateChain)
+        #expect(tlsConfiguration.privateKey == serverTLSConfiguration.privateKey)
+        #expect(tlsConfiguration.trustRoots == serverTLSConfiguration.trustRoots)
+    }
+
+    @Test("ConfigHTTPField")
+    func configHTTPField() {
+        let configReader = ConfigReader(
+            provider: InMemoryProvider(
+                values: [
+                    "initialRequestHeaders": ConfigValue(
+                        .stringArray([
+                            "X-Custom-Header: CustomValue",
+                            "X-Another-Header: AnotherValue",
+                        ]),
+                        isSecret: false
+                    )
+                ]
+            )
+        )
+        let initialRequestHeaders = configReader.stringArray(forKey: "initialRequestHeaders", as: ConfigHTTPField.self)
+        #expect(initialRequestHeaders?.count == 2)
+        #expect(initialRequestHeaders?[0].name == HTTPField.Name("X-Custom-Header"))
+        #expect(initialRequestHeaders?[0].value == "CustomValue")
+    }
+
+    let caCertificateData =
+        """
+        -----BEGIN CERTIFICATE-----
+        MIIDZDCCAkwCCQD0NlEDBAHjqjANBgkqhkiG9w0BAQsFADB0MQswCQYDVQQGEwJV
+        SzESMBAGA1UECAwJRWRpbmJ1cmdoMRIwEAYDVQQHDAlFZGluYnVyZ2gxFDASBgNV
+        BAoMC0h1bW1pbmdiaXJkMQswCQYDVQQLDAJDQTEaMBgGA1UEAwwRaHVtbWluZ2Jp
+        cmQuY29kZXMwHhcNMjUwMTI3MDg1NTM5WhcNMzAwMTI2MDg1NTM5WjB0MQswCQYD
+        VQQGEwJVSzESMBAGA1UECAwJRWRpbmJ1cmdoMRIwEAYDVQQHDAlFZGluYnVyZ2gx
+        FDASBgNVBAoMC0h1bW1pbmdiaXJkMQswCQYDVQQLDAJDQTEaMBgGA1UEAwwRaHVt
+        bWluZ2JpcmQuY29kZXMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDI
+        uzaSit8quh4TvdVPAT0QqH6gYluhsGgVjU+w55E+Yx698Os44IE5pudYiI/ufo2a
+        Ttc14uNqx15/irz6xWHYlPrAoBaH6Q14gs4Zw7ZPh1ngx8/JqzEwJ523a+CPCc73
+        Q9VdwjfN09C9DpkRpym6Kuoo3+h9/StgTmf1izf5fyNKtr1sWlRAps1H1AZpFP0B
+        K/qxCXC/oOfRzjeaQ+vw/vdEA4w998ePX0CaCkDOa/aQKZEFsjJ5w3xEhRipgzPw
+        6pMdNhvrL/MzSwJvdt9Y2EjXzhlqj6H+JU8tCseUf8u1ij0Mv6ux+oBCBmRUs2vm
+        CROEulZKLPAubjGUqi89AgMBAAEwDQYJKoZIhvcNAQELBQADggEBALkJRZaH6GtK
+        fyFP3PnTdu319XShP6feBz1v0XlTGSJYA+ufE8fruoJoB+a/AonB0BqNnt5UUBL3
+        fz3z3GEcEHiu9h83bq7vRnKYTyflqKn7YMtQegRMROLFmtPyPOvZTWt0OCKR2OwP
+        OFAdj8yblVy/rYetoOBGjvX2H9UuAn9w+3fDbWExPD4BEyeEoZnMh9xUgXau8GMu
+        bhQmaGE4lDGL8XU6a2M+XkI+YdwKQs+HviT2Cmv3QwCfBZuMnOD4U4+tcnYlz3q2
+        O67quuvn46uQFcgxaZwuzQ2vVBzSWSj5JA2GDej4UQipGFLkoLtXdckiJI0LFkHr
+        jGFTl9ts7yg=
+        -----END CERTIFICATE-----
+        """
+
+    let serverCertificateData =
+        """
+        -----BEGIN CERTIFICATE-----
+        MIIDuzCCAqOgAwIBAgIJAIKDFx1aQwi8MA0GCSqGSIb3DQEBCwUAMHQxCzAJBgNV
+        BAYTAlVLMRIwEAYDVQQIDAlFZGluYnVyZ2gxEjAQBgNVBAcMCUVkaW5idXJnaDEU
+        MBIGA1UECgwLSHVtbWluZ2JpcmQxCzAJBgNVBAsMAkNBMRowGAYDVQQDDBFodW1t
+        aW5nYmlyZC5jb2RlczAeFw0yNTAxMjcwODU1MzlaFw0zMDAxMjYwODU1MzlaMHgx
+        CzAJBgNVBAYTAlVLMRIwEAYDVQQIDAlFZGluYnVyZ2gxEjAQBgNVBAcMCUVkaW5i
+        dXJnaDEUMBIGA1UECgwLSHVtbWluZ2JpcmQxDzANBgNVBAsMBlNlcnZlcjEaMBgG
+        A1UEAwwRaHVtbWluZ2JpcmQuY29kZXMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+        ggEKAoIBAQChAarpHioO8b3MVwPFOPq+1YEFAeLZxOXnPRPof+qT0apRsYsDpQQu
+        hPWF6fvW1HcpkAGCb9e935Sx172FqHCfAMKI7JaNPn1+wZNAHd0d4tho8bgONdkf
+        s9XQZcVLRbc4Gym14sIcfKEOsPUDJISXYQ2nNprSgBVb709SO/JxpTTugJAeAqyW
+        bln4db98LpaXNoakaL9py1yUgkosD2GLJl8maueR7Aimf40MmOaVZvvTce11raVg
+        iUZtz3CkOdzFLFdQSP9CczkM7Bon8+RyXgM7BUpF9bXu8dL7kRkSu5E9S6bR8CR5
+        lwBtoXzw6187GBThVc0R9hiYM/e6cjIHAgMBAAGjTDBKMAsGA1UdDwQEAwIFoDAd
+        BgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwHAYDVR0RBBUwE4IRaHVtbWlu
+        Z2JpcmQuY29kZXMwDQYJKoZIhvcNAQELBQADggEBACGATnuWnyBK97EeiI+c+8QK
+        Aqr9DCt2NQDrC/RIjPgTMfQ3GFWB+8O2rdr2EwGSVj7ovdw8T8LNvccg8P8B6CFL
+        E2oPftWghIg5o23BnO5IovpbQKeDien9oUwiEloYvVc6k221Ah3iC/mW9VYJeFYd
+        29fhSypXao0mWnzl8CKeB665XX9Q64wRL6tzoiFzRVJCCfF3cQytpI2FzuWmkJfJ
+        ECf8CLOYAK3Ko218h14e02J3T1ZMbXJa8mSAG32HqRpABxxfBZdi88XsA6h8qKT/
+        dTF/dRScAjFXwxAwFIUVCqct+IfGokUHvkij73bCIJNZL79kRZh2MrndM/OOkNw=
+        -----END CERTIFICATE-----
+        """
+
+    let serverPrivateKeyData =
+        """
+        -----BEGIN PRIVATE KEY-----
+        MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQChAarpHioO8b3M
+        VwPFOPq+1YEFAeLZxOXnPRPof+qT0apRsYsDpQQuhPWF6fvW1HcpkAGCb9e935Sx
+        172FqHCfAMKI7JaNPn1+wZNAHd0d4tho8bgONdkfs9XQZcVLRbc4Gym14sIcfKEO
+        sPUDJISXYQ2nNprSgBVb709SO/JxpTTugJAeAqyWbln4db98LpaXNoakaL9py1yU
+        gkosD2GLJl8maueR7Aimf40MmOaVZvvTce11raVgiUZtz3CkOdzFLFdQSP9CczkM
+        7Bon8+RyXgM7BUpF9bXu8dL7kRkSu5E9S6bR8CR5lwBtoXzw6187GBThVc0R9hiY
+        M/e6cjIHAgMBAAECggEABBDdtwta9oumRl3AK5/XvS/5FR5KE0PEpoVFVm68hsUZ
+        rvxzzUDCjUYwSRRylqdA5xzK3PdkFFhsEd2n3JM3XNyRDRIkbyav1p6e0FSwu8t5
+        uZS5GCrF8+X/tUaMp+z3xoPxFrXGPx/qlUtktJKcgpIh3SIk4MH5SBwP/byjz7jZ
+        DfqDIbVG07PCwXe0LEmd8AEGT6vOXULG5SBkTwz/7BSdzgKvDWIgCDjIdDAahdhW
+        LSIn9FT1xDeCeOimFwA4ZdM96ZnFlLJwP4WBmqUWgKfsXBc+Oa8ZDlmsDEkhmzCy
+        mBNDOxJVgJ5YOURTpTRPeMoDBxkQbQ1V5MRJng9q0QKBgQDRrVORq74LqtgMOb9o
+        Ff2T3z/RE1PzW8jlXnrK3lBcW4Ivt4N4xmFCSWlW7PBTtkCGJfSMZA1MNkK1sBl7
+        L2FWqh6KymTdBCedsGFrwNiaVXmJWtUimxS3OAFr4/mJWYIIwz43wzXsxhmSOQD+
+        T3/kquDCtYq1cvPHtOdTgu/26QKBgQDEk7BNdIZw0TM8YprdC+OiaO05juXEnp2+
+        ObKCVDH0KJjpQ9OfqhppMOBG/RP34zGX8c7iJ0uRIgjlIhTHkeDQp974ei8geCTK
+        PI90/fhO8pkkpLJZVPreAdj7502jyFYuy79FjQQRMUVOF3YgCYc3kf9aqWGsGT7O
+        KkVP3GUrbwKBgFEC37vzmBzX6Fto4GwtuuisI/L6vb/T4Z3FUDobhP76GCWpiLFc
+        LG25AWslZoFhdDKgbYjki0K74DBklqPCnaAnYF+NbUT7evbxE+LXApk2lxubraeO
+        NYXIrLvrvBj2LUiHbv2KfcY6j9ywC5M2UhqebvKrw6jxfgDWA15/w4kpAoGAK682
+        asAOcFvNKwouqBjQSXNP5I6g+QTWwUNJLDVRtJShBpWQHddLbzzxWlU7bscKal3O
+        P+vDm0kY+PKN85uzfisQHd/pQSnx4w96QeF+oOzAo6gGClwcM+HtOm24j0EiBdw5
+        cVdZJAjzAdus4Im9htfnC1rA3eHuVxqFtK2hvfkCgYEAttVDzfbXDWo4X4g5ZvON
+        7ZAldvxQuHhb5JDPwfWR3H/W99tUma5T8e4UhSOU+7dng3xE+LK2aLJXZN6H4VsR
+        GeLymDyXs3JLtJyO4JvRp6C+acALua/pyLfeJj+Mk+A+76bmAftqcJ2e7rzp/EgH
+        7VbyN0IbfqD+MmEjFat0hRw=
+        -----END PRIVATE KEY-----
+        """
+
+    func getServerTLSConfiguration() throws -> TLSConfiguration {
+        let caCertificate = try NIOSSLCertificate(bytes: [UInt8](caCertificateData.utf8), format: .pem)
+        let certificate = try NIOSSLCertificate(bytes: [UInt8](serverCertificateData.utf8), format: .pem)
+        let privateKey = try NIOSSLPrivateKey(bytes: [UInt8](serverPrivateKeyData.utf8), format: .pem)
+        var tlsConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(certificate)],
+            privateKey: .privateKey(privateKey)
+        )
+        tlsConfig.trustRoots = .certificates([caCertificate])
+        return tlsConfig
+    }
+}

--- a/Tests/MQTTNIOTests/ConfigurationTests.swift
+++ b/Tests/MQTTNIOTests/ConfigurationTests.swift
@@ -35,7 +35,6 @@ struct ConfigurationTests {
                     "timeout": 20,
                     "userName": "mqtt_user",
                     "password": .init(.string("mqtt_password"), isSecret: true),
-                    "tls.config": "niossl",
                     "tls.certificateChain": .init(stringLiteral: serverCertificateData),
                     "tls.privateKey": .init(stringLiteral: serverPrivateKeyData),
                     "tls.trustRoots": .init(stringLiteral: caCertificateData),
@@ -154,7 +153,6 @@ struct ConfigurationTests {
         let configReader = ConfigReader(
             providers: [
                 InMemoryProvider(values: [
-                    "config": "niossl",
                     "certificateChain": .init(stringLiteral: serverCertificateData),
                     "privateKey": .init(stringLiteral: serverPrivateKeyData),
                     "trustRoots": .init(stringLiteral: caCertificateData),


### PR DESCRIPTION
Resolves #256

- Add an initializer for `MQTTConnectionConfiguration` that uses a `ConfigReader`
- Allow sending of a Password without a User Name (which is allowed in MQTT v5.0, but not in v3.1.1)