### PR TITLE
Default to `Logger.current` in public API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "MQTTNIO", targets: ["MQTTNIO"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.13.1"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.14.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.100.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.36.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.26.0"),

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # MQTT NIO
 
 [![sswg:sandbox|94x20](https://img.shields.io/badge/sswg-sandbox-lightgrey.svg)](https://github.com/swift-server/sswg/blob/master/process/incubation.md#sandbox-level)
-[<img src="https://img.shields.io/badge/swift-6.2.3-brightgreen.svg" alt="Swift 6.2.3" />](https://swift.org)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fswift-server-community%2Fmqtt-nio%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/swift-server-community/mqtt-nio)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fswift-server-community%2Fmqtt-nio%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/swift-server-community/mqtt-nio)
 [<img src="https://github.com/swift-server-community/mqtt-nio/workflows/CI/badge.svg" />](https://github.com/swift-server-community/mqtt-nio/workflows/CI/badge.svg)
 ![Codecov](https://img.shields.io/codecov/c/github/swift-server-community/mqtt-nio)
 
@@ -9,13 +10,15 @@ A Swift NIO based MQTT v3.1.1 and v5.0 client.
 
 MQTT (Message Queuing Telemetry Transport) is a lightweight messaging protocol that was developed by IBM and first released in 1999. It uses the pub/sub pattern and translates messages between devices, servers, and applications. It is commonly used in Internet of things (IoT) technologies.
 
-MQTTNIO is a Swift NIO based implementation of a MQTT client. It supports
-- MQTT versions 3.1.1 and 5.0.
+MQTTNIO is a Swift NIO based implementation of a MQTT client. It supports:
+
+- MQTT versions 3.1.1 and 5.0
 - Unencrypted and encrypted (via TLS) connections
 - WebSocket connections
-- Posix sockets
-- Apple's Network framework via [NIOTransportServices](https://github.com/apple/swift-nio-transport-services) (required for iOS).
-- Unix domain sockets
+- POSIX and Unix domain sockets
+- Apple's Network framework via [NIOTransportServices](https://github.com/apple/swift-nio-transport-services) (required for iOS)
+- [Swift Configuration](https://github.com/apple/swift-configuration) to create `MQTTConnectionConfiguration` from a configuration file
+- [Task-local loggers](https://swiftpackageindex.com/apple/swift-log/documentation/logging/slg-0006-task-local-logger) from SwiftLog
 
 ## Overview
 
@@ -26,8 +29,7 @@ When the closure returns the connection will be closed.
 ```swift
 try await MQTTConnection.withConnection(
     address: .hostname("mqtt.eclipse.org"),
-    identifier: "My Client",
-    logger: Logger(...)
+    identifier: "My Client"
 ) { connection in
     // You are now connected to the MQTT broker
     // The connection will be active only inside this closure

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTMessageDecoder.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTMessageDecoder.swift
@@ -6,7 +6,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Logging
 import NIOCore
 
 /// Decode ByteBuffers into MQTT Messages

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -72,7 +72,7 @@ public final actor MQTTConnection: Sendable {
     ///   - configuration: Configuration of the MQTT connection.
     ///   - identifier: Client identifier for the server. This must be unique.
     ///   - eventLoop: EventLoop to run the connection on.
-    ///   - logger: Logger to use for the connection.
+    ///   - logger: Logger to use for the connection. Defaults to the current task-local logger.
     ///   - operation: Closure handling the MQTT connection.
     ///     The closure receives the ``MQTTConnection``
     /// - Returns: Value returned from the operation closure.
@@ -81,7 +81,7 @@ public final actor MQTTConnection: Sendable {
         configuration: MQTTConnectionConfiguration = .init(),
         identifier: String = "",
         eventLoop: any EventLoop = MultiThreadedEventLoopGroup.singleton.any(),
-        logger: Logger,
+        logger: Logger = Logger.current,
         operation: (MQTTConnection) async throws -> Value
     ) async throws -> Value {
         let (connection, _) = try await self.connect(
@@ -134,7 +134,7 @@ public final actor MQTTConnection: Sendable {
     ///   - configuration: Configuration of the MQTT connection.
     ///   - session: The ``MQTTSession`` to use for the connection.
     ///   - eventLoop: EventLoop to run the connection on.
-    ///   - logger: Logger to use for the connection.
+    ///   - logger: Logger to use for the connection. Defaults to the current task-local logger.
     ///   - operation: Closure handling the MQTT connection.
     ///     The closure receives the ``MQTTConnection`` and a `Bool` indicating if there was a previous session present.
     /// - Returns: Value returned from the operation closure.
@@ -143,7 +143,7 @@ public final actor MQTTConnection: Sendable {
         configuration: MQTTConnectionConfiguration = .init(),
         session: MQTTSession,
         eventLoop: any EventLoop = MultiThreadedEventLoopGroup.singleton.any(),
-        logger: Logger,
+        logger: Logger = Logger.current,
         operation: (MQTTConnection, Bool) async throws -> Value
     ) async throws -> Value {
         do {

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -545,7 +545,7 @@ public final actor MQTTConnection: Sendable {
         _ channel: any Channel,
         configuration: MQTTConnectionConfiguration = .init(),
         session: MQTTSessionStorage,
-        logger: Logger
+        logger: Logger = Logger.current
     ) async throws -> MQTTConnection {
         if !channel.eventLoop.inEventLoop {
             return try await channel.eventLoop.flatSubmit {

--- a/Sources/MQTTNIO/MQTTNIO.docc/mqttnio-aws.md
+++ b/Sources/MQTTNIO/MQTTNIO.docc/mqttnio-aws.md
@@ -32,8 +32,7 @@ let requestURI = "/mqtt?\(signedURL.query!)"
 try await MQTTConnection.withConnection(
     address: .hostname(host),
     configuration: .init(transport: .webSocket(.init(urlPath: requestURI), tls: .enable(...))),
-    identifier: "My AWS Client",
-    logger: Logger(...)
+    identifier: "My AWS Client"
 ) { connection in
     // You are now connected to AWS IoT
 }

--- a/Sources/MQTTNIO/MQTTNIO.docc/mqttnio-connections.md
+++ b/Sources/MQTTNIO/MQTTNIO.docc/mqttnio-connections.md
@@ -12,17 +12,51 @@ When the closure returns, the connection will be closed.
 ```swift
 try await MQTTConnection.withConnection(
     address: .hostname("mqtt.eclipse.org"),
-    identifier: "My Client",
-    logger: Logger(...)
+    identifier: "My Client"
 ) { connection in
     // You are now connected to the MQTT broker
     // The connection will be active only inside this closure
 }
 ```
 
+You can wait for the connection to be closed, either by the client (by returning from the closure, calling ``MQTTConnection/close()`` or throwing an error) or by the server, with the ``MQTTConnection/waitOnClose()`` method.
+
+### MQTT v5.0
+
 If you establish a MQTT v5.0 connection (see <doc:mqttnio-v5>), you can define ``MQTTProperties`` to be sent with the `CONNECT` and `DISCONNECT` packets in the ``MQTTConnectionConfiguration/versionConfiguration``.
 
-You can wait for the connection to be closed, either by the client (by returning from the closure, calling ``MQTTConnection/close()`` or throwing an error) or by the server, with the ``MQTTConnection/waitOnClose()`` method.
+### Logging
+
+By default, `withConnection` uses the current task-local logger ([`Logger.current`](https://swiftpackageindex.com/apple/swift-log/documentation/logging/logger/current)), which by default is a `Logger` with an empty label and a log level of `.info`.
+
+You can set a custom logger for the connection by passing it via a parameter to the `withConnection` method, or you can wrap the connection creation code within a `withLogger` closure, which will set a task-local logger.
+
+```swift
+// Your custom logger
+var myLogger = Logger(label: "com.example.mqtt")
+myLogger.logLevel = .trace
+
+// Either pass the logger to the `withConnection` method
+try await MQTTConnection.withConnection(
+    address: .hostname("mqtt.eclipse.org"),
+    identifier: "My Client",
+    logger: myLogger
+) { connection in
+    // Connection events will be logged with `myLogger`
+}
+
+// Or wrap the connection creation code within a `withLogger` closure
+try await withLogger(myLogger) { _ in
+    try await MQTTConnection.withConnection(
+        address: .hostname("mqtt.eclipse.org"),
+        identifier: "My Client"
+    ) { connection in
+        // Connection events will be logged with `myLogger`
+    }
+}
+```
+
+### Different types of connections
 
 The available variants of `withConnection` are:
 - ``MQTTConnection/withConnection(address:configuration:identifier:eventLoop:logger:operation:)-(_,_,_,_,_,(MQTTConnection)->Value)``
@@ -50,8 +84,7 @@ The transport protocol can be configured through the ``MQTTConnectionConfigurati
 try await MQTTConnection.withConnection(
     address: .hostname("test.mosquitto.org", port: 8080),
     configuration: .init(transport: .webSocket(.init(...))),
-    identifier: "My WebSocket Client",
-    logger: Logger(...)
+    identifier: "My WebSocket Client"
 ) { connection in
     // Connected to the broker via WebSockets
 }
@@ -77,8 +110,7 @@ let tlsConfiguration: TLSConfiguration? = TLSConfiguration.forClient(
 try await MQTTConnection.withConnection(
     address: .hostname("test.mosquitto.org", port: 8884),
     configuration: .init(transport: .tcp(tls: .enable(.niossl(tlsConfiguration)))),
-    identifier: "My SSL Client",
-    logger: Logger(...)
+    identifier: "My SSL Client"
 ) { connection in
     // Connected to the broker with an encrypted connection
 }
@@ -102,8 +134,7 @@ MQTT NIO can connect to a local MQTT broker via a Unix Domain Socket.
 ```swift
 try await MQTTConnection.withConnection(
     address: .unixDomainSocket(path: "/path/to/broker.socket"),
-    identifier: "My UDS Client",
-    logger: Logger(...)
+    identifier: "My UDS Client"
 ) { connection in
     // Connected to the broker via a Unix Domain Socket
 }

--- a/Sources/MQTTNIO/MQTTNIO.docc/mqttnio-sessions.md
+++ b/Sources/MQTTNIO/MQTTNIO.docc/mqttnio-sessions.md
@@ -12,12 +12,11 @@ Create an ``MQTTSession`` with a client ID and pass it to the ``MQTTConnection/w
 You can check if the server has an existing session for the client ID by checking the optional `Bool` parameter passed to the closure.
 
 ```swift
-let session = MQTTSession(clientID: "My Client", logger: Logger(...))
+let session = MQTTSession(clientID: "My Client")
 
 try await MQTTConnection.withConnection(
     address: .hostname("localhost"),
-    session: session,
-    logger: Logger(...)
+    session: session
 ) { connection, sessionPresent in
     if sessionPresent {
         print("The server has an existing session for this client ID")
@@ -29,11 +28,13 @@ try await MQTTConnection.withConnection(
 
 Upon connection, if there are pending QoS 2 acknowledgements that need to be sent to the broker, they will be sent automatically by MQTTNIO.
 
+### Session Subscriptions
+
 You can also open subscriptions via ``MQTTSession/subscribe(to:subscribeProperties:unsubscribeProperties:process:)``, which will keep the subscription active across multiple connections as long as the session is not expired on the server.
 When there's an active connection that uses the session, the subscription will receive messages as normal.
 
 ```swift
-let session = MQTTSession(clientID: "My Client", logger: Logger(...))
+let session = MQTTSession(clientID: "My Client")
 
 await withThrowingTaskGroup { group in
     group.addTask {
@@ -49,8 +50,7 @@ await withThrowingTaskGroup { group in
     group.addTask {
         try await MQTTConnection.withConnection(
             address: .hostname("localhost"),
-            session: session,
-            logger: Logger(...)
+            session: session
         ) { connection, _ in
             // The subscription will receive messages as normal while this connection is active.
             // When this connection is closed, the subscription will remain active
@@ -60,10 +60,44 @@ await withThrowingTaskGroup { group in
 }
 ```
 
+#### Logging
+
+To set a custom logger for the session and the connections, you can pass it via a parameter to the ``MQTTSession/init(clientID:logger:)`` and ``MQTTConnection/withConnection(address:configuration:session:eventLoop:logger:operation:)-(_,_,_,_,_,(MQTTConnection,Bool)->Value)`` methods, or you can wrap the session and connection creation code within a `withLogger` closure, which will set a task-local logger.
+
+```swift
+var myLogger = Logger(label: "com.example.mqtt")
+myLogger.logLevel = .trace
+
+try await withLogger(myLogger) { _ in
+    let session = MQTTSession(clientID: "My Client")
+
+    await withThrowingTaskGroup { group in
+        group.addTask {
+            try await session.subscribe(...) { subscription in
+                for try await message in subscription {
+                    // Incoming messages will be logged with `myLogger`
+                }
+            }
+        }
+
+        group.addTask {
+            try await MQTTConnection.withConnection(
+                address: .hostname("localhost"),
+                session: session
+            ) {
+                // Connection events will be logged with `myLogger`
+            }
+        }
+    }
+}
+```
+
+#### Waiting for Active Subscriptions to Finish
+
 You can use the ``MQTTConnection/waitUntilNoActiveSubscriptions()`` method to wait until there are no active subscriptions opened either on the current connection or on the session the connection is using.
 
 ```swift
-let session = MQTTSession(clientID: "My Client", logger: Logger(...))
+let session = MQTTSession(clientID: "My Client")
 
 await withThrowingTaskGroup { group in
     group.addTask {
@@ -79,8 +113,7 @@ await withThrowingTaskGroup { group in
     group.addTask {
         try await MQTTConnection.withConnection(
             address: .hostname("localhost"),
-            session: session,
-            logger: Logger(...)
+            session: session
         ) { connection, _ in
             await connection.waitUntilNoActiveSubscriptions()
             // This will wait until there are no active subscriptions on the connection or the session.

--- a/Sources/MQTTNIO/MQTTNIO.docc/mqttnio-v5.md
+++ b/Sources/MQTTNIO/MQTTNIO.docc/mqttnio-v5.md
@@ -12,8 +12,7 @@ You can also provide a v5 authentication workflow as an ``MQTTAuthenticator``.
 try await MQTTConnection.withConnection(
     address: .hostname(host),
     configuration: .init(versionConfiguration: .v5_0()),
-    identifier: "My V5 Client",
-    logger: Logger(...)
+    identifier: "My V5 Client"
 ) { connection in
     // You are now connected to the MQTT v5 broker
 }

--- a/Sources/MQTTNIO/MQTTNIO.docc/mqttnio.md
+++ b/Sources/MQTTNIO/MQTTNIO.docc/mqttnio.md
@@ -6,14 +6,15 @@ A Swift NIO based v3.1.1 and v5.0 MQTT client.
 
 MQTT (Message Queuing Telemetry Transport) is a lightweight messaging protocol that was developed by IBM and first released in 1999. It uses the pub/sub pattern and translates messages between devices, servers, and applications. It is commonly used in Internet of things (IoT) technologies.
 
-MQTTNIO is a Swift NIO based implementation of a MQTT client. It supports
+MQTTNIO is a Swift NIO based implementation of a MQTT client. It supports:
 
-- MQTT versions 3.1.1 and 5.0.
+- MQTT versions 3.1.1 and 5.0
 - Unencrypted and encrypted (via TLS) connections
 - WebSocket connections
-- Posix sockets
-- Apple's Network framework via [NIOTransportServices](https://github.com/apple/swift-nio-transport-services) (required for iOS).
-- Unix domain sockets
+- POSIX and Unix domain sockets
+- Apple's Network framework via [NIOTransportServices](https://github.com/apple/swift-nio-transport-services) (required for iOS)
+- [Swift Configuration](https://github.com/apple/swift-configuration) to create ``MQTTConnectionConfiguration`` from a configuration file
+- [Task-local loggers](https://swiftpackageindex.com/apple/swift-log/documentation/logging/slg-0006-task-local-logger) from SwiftLog
 
 ### Usage
 
@@ -24,8 +25,7 @@ When the closure returns the connection will be closed.
 ```swift
 try await MQTTConnection.withConnection(
     address: .hostname("mqtt.eclipse.org"),
-    identifier: "My Client",
-    logger: Logger(...)
+    identifier: "My Client"
 ) { connection in
     // You are now connected to the MQTT broker
     // The connection will be active only inside this closure

--- a/Sources/MQTTNIO/Session/MQTTSession.swift
+++ b/Sources/MQTTNIO/Session/MQTTSession.swift
@@ -31,8 +31,8 @@ public final class MQTTSession: Sendable {
     ///
     /// - Parameters:
     ///   - clientID: Client identifier to use for this session. This must be unique.
-    ///   - logger: Logger to use for this session.
-    public init(clientID: String, logger: Logger) {
+    ///   - logger: Logger to use for this session. Defaults to the current task-local logger.
+    public init(clientID: String, logger: Logger = Logger.current) {
         (self.subscriptionsQueue, self.subscriptionsQueueContinuation) = AsyncStream.makeStream()
         self.logger = logger
         self.storage = .init(.init(clientID: clientID, logger: logger))

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -91,13 +91,14 @@ struct IntegrationTests {
 
     @Test("Keep Alive Ping")
     func keepAlivePing() async throws {
-        try await MQTTConnection.withConnection(
-            address: .hostname(Self.hostname),
-            configuration: .init(pingConfiguration: .pingInterval(.seconds(2))),
-            identifier: "keepAlivePing",
-            logger: Logger(label: #function).withLogLevel(.trace)
-        ) { connection in
-            try await Task.sleep(for: .seconds(5))
+        try await withLogger(Logger(label: #function).withLogLevel(.trace)) { _ in
+            try await MQTTConnection.withConnection(
+                address: .hostname(Self.hostname),
+                configuration: .init(pingConfiguration: .pingInterval(.seconds(2))),
+                identifier: "keepAlivePing"
+            ) { connection in
+                try await Task.sleep(for: .seconds(5))
+            }
         }
     }
 

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -25,7 +25,7 @@ import NIOTransportServices
 import NIOSSL
 #endif
 
-@Suite("Integration Tests", .defaultLogger)
+@Suite("Integration Tests", .defaultLogger(logLevel: .trace))
 struct IntegrationTests {
     static let hostname = ProcessInfo.processInfo.environment["MOSQUITTO_SERVER"] ?? "localhost"
 

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -25,7 +25,7 @@ import NIOTransportServices
 import NIOSSL
 #endif
 
-@Suite("Integration Tests")
+@Suite("Integration Tests", .defaultLogger)
 struct IntegrationTests {
     static let hostname = ProcessInfo.processInfo.environment["MOSQUITTO_SERVER"] ?? "localhost"
 
@@ -33,8 +33,7 @@ struct IntegrationTests {
     func connectWithWill() async throws {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "willSubscription",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "willSubscription"
         ) { connection in
             try await withThrowingTaskGroup { group in
                 group.addTask {
@@ -56,8 +55,7 @@ struct IntegrationTests {
                             )
                         )
                     ),
-                    identifier: "connectWithWill",
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    identifier: "connectWithWill"
                 ) { connection in
                     // force connection to close
                     _ = try await connection.sendPacket(MQTTForceDisconnectMessage()) { _ in true }
@@ -91,14 +89,12 @@ struct IntegrationTests {
 
     @Test("Keep Alive Ping")
     func keepAlivePing() async throws {
-        try await withLogger(Logger(label: #function).withLogLevel(.trace)) { _ in
-            try await MQTTConnection.withConnection(
-                address: .hostname(Self.hostname),
-                configuration: .init(pingConfiguration: .pingInterval(.seconds(2))),
-                identifier: "keepAlivePing"
-            ) { connection in
-                try await Task.sleep(for: .seconds(5))
-            }
+        try await MQTTConnection.withConnection(
+            address: .hostname(Self.hostname),
+            configuration: .init(pingConfiguration: .pingInterval(.seconds(2))),
+            identifier: "keepAlivePing"
+        ) { connection in
+            try await Task.sleep(for: .seconds(5))
         }
     }
 
@@ -107,8 +103,7 @@ struct IntegrationTests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname, port: 1884),
             configuration: .init(userName: "mqttnio", password: "mqttnio-password"),
-            identifier: "connectWithUsernameAndPassword",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "connectWithUsernameAndPassword"
         ) { connection in
             try await connection.ping()
         }
@@ -120,8 +115,7 @@ struct IntegrationTests {
             try await MQTTConnection.withConnection(
                 address: .hostname(Self.hostname, port: 1884),
                 configuration: .init(userName: "wrong", password: "wrong"),
-                identifier: "connectWithWrongUsernameAndPassword",
-                logger: Logger(label: #function).withLogLevel(.trace)
+                identifier: "connectWithWrongUsernameAndPassword"
             ) { connection in
                 try await connection.ping()
             }
@@ -133,8 +127,7 @@ struct IntegrationTests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname, port: 8080),
             configuration: .init(transport: .webSocket(.init())),
-            identifier: "webSocketConnect",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "webSocketConnect"
         ) { connection in
             try await connection.ping()
         }
@@ -164,8 +157,7 @@ struct IntegrationTests {
                 address: .hostname(Self.hostname, port: 8883),
                 configuration: .init(transport: .tcp(tls: .enable(self.getTLSConfiguration(), tlsServerName: "soto.codes"))),
                 identifier: "tlsConnect",
-                eventLoop: Self.eventLoopGroupSingleton.any(),
-                logger: Logger(label: #function).withLogLevel(.trace)
+                eventLoop: Self.eventLoopGroupSingleton.any()
             ) { connection in
                 try await connection.ping()
             }
@@ -180,8 +172,7 @@ struct IntegrationTests {
                     transport: .webSocket(.init(), tls: .enable(self.getTLSConfiguration(), tlsServerName: "soto.codes"))
                 ),
                 identifier: "webSocketAndTLSConnect",
-                eventLoop: Self.eventLoopGroupSingleton.any(),
-                logger: Logger(label: #function).withLogLevel(.trace)
+                eventLoop: Self.eventLoopGroupSingleton.any()
             ) { connection in
                 try await connection.ping()
             }
@@ -209,8 +200,7 @@ struct IntegrationTests {
                     )
                 ),
                 identifier: "tlsConnectFromP12",
-                eventLoop: Self.eventLoopGroupSingleton.any(),
-                logger: Logger(label: #function).withLogLevel(.trace)
+                eventLoop: Self.eventLoopGroupSingleton.any()
             ) { connection in
                 try await connection.ping()
             }
@@ -232,8 +222,7 @@ struct IntegrationTests {
                 address: .hostname(Self.hostname, port: 8883),
                 configuration: .init(config: configReader),
                 identifier: "tlsConnectWithConfigReader",
-                eventLoop: Self.eventLoopGroupSingleton.any(),
-                logger: Logger(label: #function).withLogLevel(.trace)
+                eventLoop: Self.eventLoopGroupSingleton.any()
             ) { connection in
                 try await connection.ping()
             }
@@ -278,8 +267,7 @@ struct IntegrationTests {
     func unixDomainSocketConnect() async throws {
         try await MQTTConnection.withConnection(
             address: .unixDomainSocket(path: Self.rootPath + "/mosquitto/socket/mosquitto.sock"),
-            identifier: "unixDomainSocketConnect",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "unixDomainSocketConnect"
         ) { connection in
             try await connection.ping()
         }
@@ -289,8 +277,7 @@ struct IntegrationTests {
     func publish(qos: MQTTQoS) async throws {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "publishQoS\(qos.rawValue)",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "publishQoS\(qos.rawValue)"
         ) { connection in
             try await connection.publish(
                 to: "testMQTTPublishQoS",
@@ -304,8 +291,7 @@ struct IntegrationTests {
     func sendPingreq() async throws {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "sendPingreq",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "sendPingreq"
         ) { connection in
             try await connection.ping()
         }
@@ -316,8 +302,7 @@ struct IntegrationTests {
         await #expect(throws: MQTTError.serverClosedConnection) {
             try await MQTTConnection.withConnection(
                 address: .hostname(Self.hostname),
-                identifier: "serverDisconnect",
-                logger: Logger(label: #function).withLogLevel(.trace)
+                identifier: "serverDisconnect"
             ) { connection in
                 try await connection.sendPacket(MQTTForceDisconnectMessage()) { _ in true }
             }
@@ -333,8 +318,7 @@ struct IntegrationTests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname, port: 8080),
             configuration: .init(transport: .webSocket(.init())),
-            identifier: "publishRetain",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "publishRetain"
         ) { connection in
             try await withThrowingTaskGroup { group in
                 group.addTask {
@@ -371,8 +355,7 @@ struct IntegrationTests {
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname, port: 8080),
                     configuration: .init(transport: .webSocket(.init())),
-                    identifier: "publishToClient_subscriber",
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    identifier: "publishToClient_subscriber"
                 ) { connection in
                     try await connection.subscribe(
                         to: [
@@ -403,8 +386,7 @@ struct IntegrationTests {
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname, port: 8080),
                     configuration: .init(transport: .webSocket(.init())),
-                    identifier: "publishToClient_publisher",
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    identifier: "publishToClient_publisher"
                 ) { connection in
                     try await Task.sleep(for: .seconds(1))
                     try await connection.publish(to: "testAtLeastOnce", payload: payload, qos: .atLeastOnce)
@@ -426,8 +408,7 @@ struct IntegrationTests {
             group.addTask {
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
-                    identifier: "publishLargePayloadToClient_subscriber",
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    identifier: "publishLargePayloadToClient_subscriber"
                 ) { connection in
                     try await connection.subscribe(to: [.init(topicFilter: "testLargeAtLeastOnce", qos: .atLeastOnce)]) { subscription in
                         try await confirmation("publishLargePayloadToClient") { receivedMessage in
@@ -446,8 +427,7 @@ struct IntegrationTests {
             group.addTask {
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
-                    identifier: "publishLargePayloadToClient_publisher",
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    identifier: "publishLargePayloadToClient_publisher"
                 ) { connection in
                     try await Task.sleep(for: .seconds(1))
                     try await connection.publish(to: "testLargeAtLeastOnce", payload: payload, qos: .atLeastOnce)
@@ -464,20 +444,18 @@ struct IntegrationTests {
         // `sessionPresent` should be false as this is the first connection with this client identifier
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "sessionPresent",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "sessionPresent"
         ) { connection in
             try await connection.ping()
         }
 
-        let session = MQTTSession(clientID: "sessionPresent", logger: Logger(label: #function).withLogLevel(.trace))
+        let session = MQTTSession(clientID: "sessionPresent")
 
         // Second connection with a `MQTTSession` with same client identifier (and `cleanSession` automatically set to false)
         // `sessionPresent` should be false as previous connection was with `cleanSession` true
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            session: session,
-            logger: Logger(label: #function).withLogLevel(.trace)
+            session: session
         ) { connection, sessionPresent in
             #expect(sessionPresent == false)
             try await connection.ping()
@@ -487,8 +465,7 @@ struct IntegrationTests {
         // `sessionPresent` should be true
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            session: session,
-            logger: Logger(label: #function).withLogLevel(.trace)
+            session: session
         ) { connection, sessionPresent in
             #expect(sessionPresent == true)
             try await connection.ping()
@@ -499,8 +476,7 @@ struct IntegrationTests {
     func subscribeAll() async throws {
         try await MQTTConnection.withConnection(
             address: .hostname("broker.hivemq.com"),
-            identifier: "subscribeAll",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "subscribeAll"
         ) { connection in
             try await connection.subscribe(to: [.init(topicFilter: "test/#", qos: .exactlyOnce)]) { subscription in
                 try await Task.sleep(for: .seconds(5))
@@ -513,8 +489,7 @@ struct IntegrationTests {
     func rawIPConnect() async throws {
         try await MQTTConnection.withConnection(
             address: .hostname("127.0.0.1"),
-            identifier: "rawIPConnect",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "rawIPConnect"
         ) { connection in
             try await connection.ping()
         }
@@ -525,8 +500,7 @@ struct IntegrationTests {
     func packetID() async throws {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "packetID",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "packetID"
         ) { connection in
             let initial = await connection.globalPacketId.load(ordering: .relaxed)
             try await connection.publish(
@@ -550,8 +524,7 @@ struct IntegrationTests {
     func multiLevelWildcard() async throws {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "multiLevelWildcard",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "multiLevelWildcard"
         ) { connection in
             try await withThrowingTaskGroup { group in
                 group.addTask {
@@ -590,8 +563,7 @@ struct IntegrationTests {
     func singleLevelWildcard() async throws {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "singleLevelWildcard",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "singleLevelWildcard"
         ) { connection in
             try await withThrowingTaskGroup { group in
                 group.addTask {
@@ -633,8 +605,7 @@ struct IntegrationTests {
     func overlappingSubscriptions() async throws {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "overlappingSubscriptions",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "overlappingSubscriptions"
         ) { connection in
             try await withThrowingTaskGroup { group in
                 group.addTask {
@@ -670,8 +641,7 @@ struct IntegrationTests {
     func cancellation() async throws {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "cancellation",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "cancellation"
         ) { connection in
             await withThrowingTaskGroup { group in
                 group.addTask {
@@ -692,8 +662,7 @@ struct IntegrationTests {
     func alreadyCancelled() async throws {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "alreadyCancelled",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "alreadyCancelled"
         ) { connection in
             await withThrowingTaskGroup(of: Void.self) { group in
                 group.cancelAll()
@@ -716,8 +685,7 @@ struct IntegrationTests {
             group.addTask {
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
-                    identifier: "inflight_subscriber",
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    identifier: "inflight_subscriber"
                 ) { connection in
                     try await connection.subscribe(to: [.init(topicFilter: "testInflight", qos: .exactlyOnce)]) { subscription in
                         for try await message in subscription {
@@ -730,12 +698,11 @@ struct IntegrationTests {
 
             group.addTask {
                 try await Task.sleep(for: .milliseconds(500))
-                let session = MQTTSession(clientID: "inflight_publisher", logger: Logger(label: #function).withLogLevel(.trace))
+                let session = MQTTSession(clientID: "inflight_publisher")
 
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
-                    session: session,
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    session: session
                 ) { connection, sessionPresent in
                     async let _ = connection.publish(to: "testInflight", payload: ByteBuffer(string: "test"), qos: .exactlyOnce)
                     connection.close()
@@ -745,8 +712,7 @@ struct IntegrationTests {
 
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
-                    session: session,
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    session: session
                 ) { connection, sessionPresent in
                     try await connection.ping()
                 }
@@ -760,15 +726,14 @@ struct IntegrationTests {
 
     @Test("Multiple Connections with Same Session")
     func multipleConnectionsWithSameSession() async throws {
-        let session = MQTTSession(clientID: "multipleConnectionsWithSameSession", logger: Logger(label: #function).withLogLevel(.trace))
+        let session = MQTTSession(clientID: "multipleConnectionsWithSameSession")
 
         await #expect(throws: MQTTError.alreadyConnectedWithSession) {
             try await withThrowingTaskGroup { group in
                 group.addTask {
                     try await MQTTConnection.withConnection(
                         address: .hostname(Self.hostname),
-                        session: session,
-                        logger: Logger(label: #function).withLogLevel(.trace)
+                        session: session
                     ) { connection, sessionPresent in
                         try await connection.subscribe(to: [.init(topicFilter: "multipleConnWithSession1", qos: .atMostOnce)]) { subscription in
                             for try await _ in subscription {}
@@ -779,8 +744,7 @@ struct IntegrationTests {
                 group.addTask {
                     try await MQTTConnection.withConnection(
                         address: .hostname(Self.hostname),
-                        session: session,
-                        logger: Logger(label: #function).withLogLevel(.trace)
+                        session: session
                     ) { connection, sessionPresent in
                         try await connection.subscribe(to: [.init(topicFilter: "multipleConnWithSession2", qos: .atMostOnce)]) { subscription in
                             for try await _ in subscription {}
@@ -798,13 +762,12 @@ struct IntegrationTests {
         // Make an initial connection with `cleanSession` to clear any existing session state
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "subscribeWithSessionBeforeConnection",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "subscribeWithSessionBeforeConnection"
         ) { connection in
             try await connection.ping()
         }
 
-        let session = MQTTSession(clientID: "subscribeWithSessionBeforeConnection", logger: Logger(label: #function).withLogLevel(.trace))
+        let session = MQTTSession(clientID: "subscribeWithSessionBeforeConnection")
 
         await withThrowingTaskGroup { group in
             group.addTask {
@@ -818,8 +781,7 @@ struct IntegrationTests {
             group.addTask {
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
-                    session: session,
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    session: session
                 ) { connection, sessionPresent in
                     // Wait for the subscription to be established before publishing
                     try await Task.sleep(for: .milliseconds(100))
@@ -830,8 +792,7 @@ struct IntegrationTests {
 
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
-                    session: session,
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    session: session
                 ) { connection, sessionPresent in
                     #expect(sessionPresent)
                     try await connection.publish(to: "subscribeWithSessionBeforeConnection", payload: ByteBuffer(string: "test2"), qos: .atLeastOnce)
@@ -842,18 +803,15 @@ struct IntegrationTests {
 
     @Test("Subscribe with Session after Connection")
     func subscribeWithSessionAfterConnection() async throws {
-        let logger = Logger(label: #function).withLogLevel(.trace)
-
         // Make an initial connection with `cleanSession` to clear any existing session state
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "subscribeWithSessionAfterConnection",
-            logger: logger
+            identifier: "subscribeWithSessionAfterConnection"
         ) { connection in
             try await connection.ping()
         }
 
-        let session = MQTTSession(clientID: "subscribeWithSessionAfterConnection", logger: logger)
+        let session = MQTTSession(clientID: "subscribeWithSessionAfterConnection")
 
         let (stream, continuation) = AsyncStream<Void>.makeStream()
 
@@ -872,8 +830,7 @@ struct IntegrationTests {
             group.addTask {
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
-                    session: session,
-                    logger: logger
+                    session: session
                 ) { connection, sessionPresent in
                     #expect(!sessionPresent)
 
@@ -887,8 +844,7 @@ struct IntegrationTests {
 
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
-                    session: session,
-                    logger: logger
+                    session: session
                 ) { connection, sessionPresent in
                     #expect(sessionPresent)
                     try await connection.publish(to: "subscribeWithSessionAfterConnection", payload: ByteBuffer(string: "test2"), qos: .atLeastOnce)
@@ -902,13 +858,12 @@ struct IntegrationTests {
         // Make an initial connection with `cleanSession` to clear any existing session state
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "closeSubscriptionsNoSessionPresent",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "closeSubscriptionsNoSessionPresent"
         ) { connection in
             try await connection.ping()
         }
 
-        let session = MQTTSession(clientID: "closeSubscriptionsNoSessionPresent", logger: Logger(label: #function).withLogLevel(.trace))
+        let session = MQTTSession(clientID: "closeSubscriptionsNoSessionPresent")
 
         await withThrowingTaskGroup { group in
             group.addTask {
@@ -922,8 +877,7 @@ struct IntegrationTests {
             group.addTask {
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
-                    session: session,
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    session: session
                 ) { connection, sessionPresent in
                     // Wait for the subscription to be established before publishing
                     try await Task.sleep(for: .milliseconds(100))
@@ -936,16 +890,14 @@ struct IntegrationTests {
                 // Make a connection with `cleanSession` to clear existing session state
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
-                    identifier: "closeSubscriptionsNoSessionPresent",
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    identifier: "closeSubscriptionsNoSessionPresent"
                 ) { connection in
                     try await connection.ping()
                 }
 
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
-                    session: session,
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    session: session
                 ) { connection, sessionPresent in
                     // The previous connection was with `cleanSession` true,
                     // so even though this connection is with the same session,
@@ -962,15 +914,12 @@ struct IntegrationTests {
         // Make an initial connection with `cleanSession` to clear any existing session state
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "closeSubscriptions",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "closeSubscriptions"
         ) { connection in
             try await connection.ping()
         }
 
-        let logger = Logger(label: #function).withLogLevel(.trace)
-
-        let session = MQTTSession(clientID: "closeSubscriptions", logger: logger)
+        let session = MQTTSession(clientID: "closeSubscriptions")
 
         await withThrowingTaskGroup { group in
             let (stream, continuation) = AsyncStream<Void>.makeStream()
@@ -987,8 +936,7 @@ struct IntegrationTests {
             group.addTask {
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
-                    session: session,
-                    logger: logger
+                    session: session
                 ) { connection, sessionPresent in
                     try await withThrowingTaskGroup { group in
                         group.addTask {
@@ -1014,18 +962,15 @@ struct IntegrationTests {
 
     @Test("Failed Subscription on Session")
     func failedSubscriptionOnSession() async throws {
-        let logger = Logger(label: #function).withLogLevel(.trace)
-
         // Make an initial connection with `cleanSession` to clear any existing session state
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "failedSubscriptionOnSession",
-            logger: logger
+            identifier: "failedSubscriptionOnSession"
         ) { connection in
             try await connection.ping()
         }
 
-        let session = MQTTSession(clientID: "failedSubscriptionOnSession", logger: logger)
+        let session = MQTTSession(clientID: "failedSubscriptionOnSession")
 
         await withThrowingTaskGroup { group in
             group.addTask {
@@ -1040,8 +985,7 @@ struct IntegrationTests {
             group.addTask {
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
-                    session: session,
-                    logger: logger
+                    session: session
                 ) { connection, sessionPresent in
                     #expect(!sessionPresent)
                     try await connection.ping()
@@ -1052,24 +996,21 @@ struct IntegrationTests {
 
     @Test("Connection Subscription Cleanup", arguments: [true, false])
     func connectionSubscriptionCleanup(clientClose: Bool) async throws {
-        let logger = Logger(label: #function).withLogLevel(.trace)
         let identifier = "connectionSubscriptionCleanup_" + (clientClose ? "clientClose" : "forceDisconnect")
 
         // Make an initial connection with `cleanSession` to clear any existing session state
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: identifier,
-            logger: logger
+            identifier: identifier
         ) { connection in
             try await connection.ping()
         }
 
-        let session = MQTTSession(clientID: identifier, logger: logger)
+        let session = MQTTSession(clientID: identifier)
 
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            session: session,
-            logger: logger
+            session: session
         ) { connection, sessionPresent in
             #expect(!sessionPresent)
 
@@ -1106,18 +1047,15 @@ struct IntegrationTests {
 
     @Test("Wait Until No Active Subscriptions")
     func waitUntilNoActiveSubscriptions() async throws {
-        let logger = Logger(label: "Integration.\(#function)").withLogLevel(.trace)
-
         // Make an initial connection with `cleanSession` to clear any existing session state
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "waitUntilNoActiveSubscriptions",
-            logger: logger
+            identifier: "waitUntilNoActiveSubscriptions"
         ) { connection in
             try await connection.ping()
         }
 
-        let session = MQTTSession(clientID: "waitUntilNoActiveSubscriptions", logger: logger)
+        let session = MQTTSession(clientID: "waitUntilNoActiveSubscriptions")
 
         try await withThrowingTaskGroup { group in
             let (connectionStream, connectionContinuation) = AsyncStream.makeStream(of: Void.self)
@@ -1136,8 +1074,7 @@ struct IntegrationTests {
             group.addTask {
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
-                    session: session,
-                    logger: logger
+                    session: session
                 ) { connection, sessionPresent in
                     #expect(!sessionPresent)
 
@@ -1186,19 +1123,16 @@ struct IntegrationTests {
 
     @Test("Cancel Active Subscriptions Wait On Close")
     func cancelActiveSubscriptionsWait() async throws {
-        let logger = Logger(label: #function).withLogLevel(.trace)
-
         // Make an initial connection with `cleanSession` to clear any existing session state
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            identifier: "cancelActiveSubscriptionsWait",
-            logger: logger
+            identifier: "cancelActiveSubscriptionsWait"
         ) { connection in
             try await connection.ping()
         }
 
         let (stream, cont) = AsyncStream.makeStream(of: Void.self)
-        let session = MQTTSession(clientID: "cancelActiveSubscriptionsWait", logger: logger)
+        let session = MQTTSession(clientID: "cancelActiveSubscriptionsWait")
         async let _ = session.subscribe(to: [.init(topicFilter: "test", qos: .atLeastOnce)]) { sub in
             for try await _ in sub {
                 cont.yield()
@@ -1209,8 +1143,7 @@ struct IntegrationTests {
         await #expect(throws: MQTTError.connectionClosed) {
             try await MQTTConnection.withConnection(
                 address: .hostname(Self.hostname),
-                session: session,
-                logger: logger
+                session: session
             ) { connection, sessionPresent in
                 // make sure the subscriptions have been sent before sending a publish
                 try await Task.sleep(for: .milliseconds(50))
@@ -1226,8 +1159,7 @@ struct IntegrationTests {
         await #expect(throws: MQTTError.serverClosedConnection) {
             try await MQTTConnection.withConnection(
                 address: .hostname(Self.hostname),
-                session: session,
-                logger: logger
+                session: session
             ) { connection, sessionPresent in
                 try await connection.publish(to: "test", payload: .init(), qos: .atLeastOnce)
                 await stream.first { _ in true }
@@ -1244,8 +1176,7 @@ struct IntegrationTests {
         // expect waitUntilNoActiveSubscriptions to throw error as it has been cancelled
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            session: session,
-            logger: logger
+            session: session
         ) { connection, sessionPresent in
             try await connection.publish(to: "test", payload: .init(), qos: .atLeastOnce)
             await stream.first { _ in true }

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Logging
 import NIOCore
 import NIOFoundationCompat
 import Testing
@@ -20,7 +21,7 @@ import NIOTransportServices
 import NIOSSL
 #endif
 
-@Suite("Integration v5 protocol Tests", .defaultLogger)
+@Suite("Integration v5 protocol Tests", .defaultLogger(logLevel: .trace))
 struct IntegrationV5Tests {
     static let hostname = ProcessInfo.processInfo.environment["MOSQUITTO_SERVER"] ?? "localhost"
 

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import Logging
 import NIOCore
 import NIOFoundationCompat
 import Testing
@@ -21,7 +20,7 @@ import NIOTransportServices
 import NIOSSL
 #endif
 
-@Suite("Integration v5 protocol Tests")
+@Suite("Integration v5 protocol Tests", .defaultLogger)
 struct IntegrationV5Tests {
     static let hostname = ProcessInfo.processInfo.environment["MOSQUITTO_SERVER"] ?? "localhost"
 
@@ -30,8 +29,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "connectV5",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "connectV5"
         ) { connection in
             try await connection.ping()
         }
@@ -42,8 +40,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "willSubscriptionV5",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "willSubscriptionV5"
         ) { connection in
             try await withThrowingTaskGroup { group in
                 group.addTask {
@@ -67,8 +64,7 @@ struct IntegrationV5Tests {
                             )
                         )
                     ),
-                    identifier: "connectWithWillV5",
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    identifier: "connectWithWillV5"
                 ) { connection in
                     // force connection to close
                     _ = try await connection.sendPacket(MQTTForceDisconnectMessage()) { _ in true }
@@ -90,8 +86,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0(connectProperties: .init([property]))),
-            identifier: "connectWithPropertyV5_\(property)",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "connectWithPropertyV5_\(property)"
         ) { connection in
             try await connection.ping()
         }
@@ -99,12 +94,11 @@ struct IntegrationV5Tests {
 
     @Test("Connect with No Identifier")
     func connectWithNoIdentifier() async throws {
-        let session = MQTTSession(clientID: "", logger: Logger(label: #function).withLogLevel(.trace))
+        let session = MQTTSession(clientID: "")
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            session: session,
-            logger: Logger(label: #function).withLogLevel(.trace)
+            session: session
         ) { connection, sessionPresent in
         }
         #expect(try !session.storage.borrow { $0.clientID }.isEmpty)
@@ -115,8 +109,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "publishV5QoS\(qos.rawValue)WithProperty\(String(describing: property))",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "publishV5QoS\(qos.rawValue)WithProperty\(String(describing: property))"
         ) { connection in
             let properties: MQTTProperties = if let property { .init([property]) } else { .init() }
             _ = try await connection.v5.publish(
@@ -136,8 +129,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "subscribeFlagsV5",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "subscribeFlagsV5"
         ) { connection in
             try await withThrowingTaskGroup { group in
                 group.addTask {
@@ -185,8 +177,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "contentTypeV5",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "contentTypeV5"
         ) { connection in
             try await withThrowingTaskGroup { group in
                 group.addTask {
@@ -225,8 +216,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "userPropertyV5",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "userPropertyV5"
         ) { connection in
             try await withThrowingTaskGroup { group in
                 group.addTask {
@@ -259,7 +249,7 @@ struct IntegrationV5Tests {
 
     @Test("Session Expiry Interval")
     func sessionExpiryInterval() async throws {
-        let session = MQTTSession(clientID: "sessionExpiryIntervalV5", logger: Logger(label: #function).withLogLevel(.trace))
+        let session = MQTTSession(clientID: "sessionExpiryIntervalV5")
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(
@@ -268,8 +258,7 @@ struct IntegrationV5Tests {
                     disconnectProperties: [.sessionExpiryInterval(0)]
                 )
             ),
-            session: session,
-            logger: Logger(label: #function).withLogLevel(.trace)
+            session: session
         ) { connection, sessionPresent in
             // First connection with this session, `sessionPresent` should be false
             #expect(sessionPresent == false)
@@ -293,8 +282,7 @@ struct IntegrationV5Tests {
                             disconnectProperties: [.sessionExpiryInterval(3600)]
                         )
                     ),
-                    session: session,
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    session: session
                 ) { connection, sessionPresent in
                     // We used the same session in the previous connection,
                     // but the Session Expiry Interval was set to 0
@@ -311,8 +299,7 @@ struct IntegrationV5Tests {
                             disconnectProperties: [.sessionExpiryInterval(4)]
                         )
                     ),
-                    session: session,
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    session: session
                 ) { connection, sessionPresent in
                     // We used the same session in the previous connection,
                     // and the Session Expiry Interval was long enough for the session to still be valid
@@ -326,8 +313,7 @@ struct IntegrationV5Tests {
                 try await MQTTConnection.withConnection(
                     address: .hostname(Self.hostname),
                     configuration: .init(versionConfiguration: .v5_0()),
-                    session: session,
-                    logger: Logger(label: #function).withLogLevel(.trace)
+                    session: session
                 ) { connection, sessionPresent in
                     // We used the same session in the previous connection,
                     // but the session should have expired by now
@@ -346,8 +332,7 @@ struct IntegrationV5Tests {
             try await MQTTConnection.withConnection(
                 address: .hostname(Self.hostname),
                 configuration: .init(versionConfiguration: .v5_0(connectProperties: [.authenticationMethod("test")])),
-                identifier: "badAuthenticationMethodV5",
-                logger: Logger(label: #function).withLogLevel(.trace)
+                identifier: "badAuthenticationMethodV5"
             ) { _ in }
         }
     }
@@ -357,8 +342,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "invalidTopicNameV5",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "invalidTopicNameV5"
         ) { connection in
             _ = await #expect(throws: MQTTPacketError.invalidTopicName) {
                 try await connection.v5.publish(
@@ -376,8 +360,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "badPublishV5",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "badPublishV5"
         ) { connection in
             let error = await #expect(throws: MQTTError.self) {
                 try await connection.v5.publish(
@@ -402,8 +385,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "outOfRangeTopicAliasV5",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "outOfRangeTopicAliasV5"
         ) { connection in
             _ = await #expect(throws: MQTTPacketError.topicAliasOutOfRange) {
                 try await connection.v5.publish(
@@ -421,8 +403,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "publishWithSubscriptionIDV5",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "publishWithSubscriptionIDV5"
         ) { connection in
             _ = await #expect(throws: MQTTPacketError.publishIncludesSubscription) {
                 try await connection.v5.publish(
@@ -440,8 +421,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "reAuthV5",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "reAuthV5"
         ) { connection in
             struct EmptyAuthenticator: MQTTAuthenticator {
                 var methodName: String { "Empty" }
@@ -469,8 +449,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname("broker.hivemq.com"),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "subscribeAllV5",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "subscribeAllV5"
         ) { connection in
             try await connection.v5.subscribe(to: [.init(topicFilter: "test/#", qos: .exactlyOnce)]) { _ in
                 try await Task.sleep(for: .seconds(5))
@@ -483,8 +462,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "multiLevelWildcardV5",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "multiLevelWildcardV5"
         ) { connection in
             try await withThrowingTaskGroup { group in
                 group.addTask {
@@ -534,8 +512,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "singleLevelWildcardV5",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "singleLevelWildcardV5"
         ) { connection in
             try await withThrowingTaskGroup { group in
                 group.addTask {
@@ -587,8 +564,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "overlappingSubscriptionsV5",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "overlappingSubscriptionsV5"
         ) { connection in
             try await withThrowingTaskGroup { group in
                 group.addTask {
@@ -630,8 +606,7 @@ struct IntegrationV5Tests {
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: .init(versionConfiguration: .v5_0()),
-            identifier: "maximumPacketSizeV5QoS\(qos.rawValue)",
-            logger: Logger(label: #function).withLogLevel(.trace)
+            identifier: "maximumPacketSizeV5QoS\(qos.rawValue)"
         ) { connection in
             let largePayload = ByteBufferAllocator().buffer(repeating: 0xFF, count: 150_000)
             await #expect(throws: MQTTError.packetTooLarge) {

--- a/Tests/IntegrationTests/Utils/Logger+withLogLevel.swift
+++ b/Tests/IntegrationTests/Utils/Logger+withLogLevel.swift
@@ -18,6 +18,8 @@ extension Logger {
 }
 
 struct DefaultLoggerTrait: TestTrait, SuiteTrait, TestScoping {
+    let logLevel: Logger.Level
+
     var isRecursive: Bool { true }
 
     func provideScope(
@@ -25,7 +27,7 @@ struct DefaultLoggerTrait: TestTrait, SuiteTrait, TestScoping {
         testCase: Test.Case?,
         performing function: @concurrent @Sendable () async throws -> Void
     ) async throws {
-        try await withLogger(Logger(label: test.displayName ?? test.name).withLogLevel(.trace)) { _ in
+        try await withLogger(Logger(label: test.displayName ?? test.name).withLogLevel(logLevel)) { _ in
             try await function()
         }
     }
@@ -34,6 +36,6 @@ struct DefaultLoggerTrait: TestTrait, SuiteTrait, TestScoping {
 extension Trait where Self == DefaultLoggerTrait {
     /// A trait that provides a default task-local `Logger` for all tests and suites.
     ///
-    /// The logger is configured with a log level of `trace` and a label that corresponds to the test display name.
-    static var defaultLogger: Self { Self() }
+    /// The logger is configured with the provided log level and a label that corresponds to the test display name.
+    static func defaultLogger(logLevel: Logger.Level) -> Self { Self(logLevel: logLevel) }
 }

--- a/Tests/IntegrationTests/Utils/Logger+withLogLevel.swift
+++ b/Tests/IntegrationTests/Utils/Logger+withLogLevel.swift
@@ -7,6 +7,7 @@
 //
 
 import Logging
+import Testing
 
 extension Logger {
     func withLogLevel(_ logLevel: Logger.Level) -> Logger {
@@ -14,4 +15,25 @@ extension Logger {
         logger.logLevel = logLevel
         return logger
     }
+}
+
+struct DefaultLoggerTrait: TestTrait, SuiteTrait, TestScoping {
+    var isRecursive: Bool { true }
+
+    func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: @concurrent @Sendable () async throws -> Void
+    ) async throws {
+        try await withLogger(Logger(label: test.displayName ?? test.name).withLogLevel(.trace)) { _ in
+            try await function()
+        }
+    }
+}
+
+extension Trait where Self == DefaultLoggerTrait {
+    /// A trait that provides a default task-local `Logger` for all tests and suites.
+    ///
+    /// The logger is configured with a log level of `trace` and a label that corresponds to the test display name.
+    static var defaultLogger: Self { Self() }
 }

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -14,7 +14,7 @@ import Testing
 
 @testable import MQTTNIO
 
-@Suite("MQTTConnection Tests", .defaultLogger)
+@Suite("MQTTConnection Tests", .defaultLogger(logLevel: .trace))
 struct MQTTConnectionTests {
     @Test
     func testConnectDisconnect() async throws {

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -589,12 +589,7 @@ struct MQTTConnectionTests {
     @Test("Subscription with Session")
     func subscriptionWithSession() async throws {
         try await withLogger(Logger(label: #function).withLogLevel(.trace)) { _ in
-            let session = MQTTSession(clientID: "subscriptionWithSession")
-
-            try await withTestSessionSubscription(
-                to: [.init(topicFilter: "testTopic", qos: .atLeastOnce)],
-                session: session
-            ) { subscription in
+            try await withTestSessionSubscription(to: [.init(topicFilter: "testTopic", qos: .atLeastOnce)]) { subscription in
                 var iterator = subscription.makeAsyncIterator()
                 let event = try #require(try await iterator.next())
                 #expect(event.payload == ByteBuffer(string: "TestPayload"))
@@ -623,49 +618,46 @@ struct MQTTConnectionTests {
 
     @Test("Wait Until No Active Subscriptions")
     func waitUntilNoActiveSubscriptions() async throws {
-        let logger = Logger(label: #function).withLogLevel(.trace)
-        let session = MQTTSession(clientID: "waitUntilNoActiveSubscriptions", logger: logger)
-
         let subscribeInfos: [[MQTTSubscribeInfoV5]] = [
             [.init(topicFilter: "testTopic1", qos: .atMostOnce)],
             [.init(topicFilter: "testTopic2", qos: .atMostOnce)],
             [.init(topicFilter: "testTopic3", qos: .atMostOnce)],
         ]
 
-        try await withTestSessionSubscriptions(
-            to: subscribeInfos,
-            session: session,
-            logger: logger
-        ) { subscription in
-            var iterator = subscription.makeAsyncIterator()
-            let event = try #require(try await iterator.next())
-            #expect(event.payload == ByteBuffer(string: "TestPayload"))
-        } client: { connection in
-            try await connection.waitUntilNoActiveSubscriptions()
-        } server: { channel in
-            for subscribeInfo in subscribeInfos {
-                // Send PUBLISH
-                let publish = MQTTPublishPacket(
-                    publish: .init(
-                        qos: .atMostOnce,
-                        retain: false,
-                        topicName: subscribeInfo.first!.topicFilter,
-                        payload: ByteBuffer(string: "TestPayload"),
-                        properties: .init()
-                    ),
-                    packetId: 32768
-                )
-                try await channel.writeInboundPacket(publish, version: .v3_1_1)
+        try await withLogger(Logger(label: #function).withLogLevel(.trace)) { _ in
+            try await withTestSessionSubscriptions(to: subscribeInfos) { subscription in
+                var iterator = subscription.makeAsyncIterator()
+                let event = try #require(try await iterator.next())
+                #expect(event.payload == ByteBuffer(string: "TestPayload"))
+            } client: { connection in
+                try await connection.waitUntilNoActiveSubscriptions()
+            } server: { channel in
+                for subscribeInfo in subscribeInfos {
+                    // Send PUBLISH
+                    let publish = MQTTPublishPacket(
+                        publish: .init(
+                            qos: .atMostOnce,
+                            retain: false,
+                            topicName: subscribeInfo.first!.topicFilter,
+                            payload: ByteBuffer(string: "TestPayload"),
+                            properties: .init()
+                        ),
+                        packetId: 32768
+                    )
+                    try await channel.writeInboundPacket(publish, version: .v3_1_1)
+                }
             }
         }
     }
 
     @Test("Wait with No Active Subscriptions")
     func waitWithNoActiveSubscriptions() async throws {
-        try await withTestMQTTServer(logger: Logger(label: #function).withLogLevel(.trace)) { connection in
-            // Should return immediately as there are no active subscriptions
-            try await connection.waitUntilNoActiveSubscriptions()
-        } server: { _ in
+        try await withLogger(Logger(label: #function).withLogLevel(.trace)) { _ in
+            try await withTestMQTTServer { connection in
+                // Should return immediately as there are no active subscriptions
+                try await connection.waitUntilNoActiveSubscriptions()
+            } server: { _ in
+            }
         }
     }
 }

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -14,20 +14,18 @@ import Testing
 
 @testable import MQTTNIO
 
-@Suite("MQTTConnection Tests")
+@Suite("MQTTConnection Tests", .defaultLogger)
 struct MQTTConnectionTests {
     @Test
     func testConnectDisconnect() async throws {
-        try await withLogger(Logger(label: #function).withLogLevel(.trace)) { _ in
-            try await withTestMQTTServer { _ in
-            } server: { _ in
-            }
+        try await withTestMQTTServer { _ in
+        } server: { _ in
         }
     }
 
     @Test
     func testPublishQoS0ClientToServer() async throws {
-        try await withTestMQTTServer(logger: Logger(label: #function).withLogLevel(.trace)) { connection in
+        try await withTestMQTTServer { connection in
             try await connection.publish(to: "testTopic", payload: ByteBuffer(string: "TestPayload"), qos: .atMostOnce, retain: false)
         } server: { channel in
             let packet = try await channel.waitForOutboundPacket()
@@ -41,7 +39,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testPublishQoS1ClientToServer() async throws {
-        try await withTestMQTTServer(logger: Logger(label: #function).withLogLevel(.trace)) { connection in
+        try await withTestMQTTServer { connection in
             try await connection.publish(to: "testTopic", payload: ByteBuffer(string: "TestPayload"), qos: .atLeastOnce, retain: false)
         } server: { channel in
             let packet = try await channel.waitForOutboundPacket()
@@ -57,7 +55,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testPublishQoS2ClientToServer() async throws {
-        try await withTestMQTTServer(logger: Logger(label: #function).withLogLevel(.trace)) { connection in
+        try await withTestMQTTServer { connection in
             try await connection.publish(to: "testTopic", payload: ByteBuffer(string: "TestPayload"), qos: .exactlyOnce, retain: false)
         } server: { channel in
             // receive PUBLISH
@@ -83,10 +81,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testSubscribeAndPublishQoS0() async throws {
-        try await withTestSubscription(
-            subscribeInfos: [.init(topicFilter: "testTopic", qos: .atMostOnce)],
-            logger: Logger(label: #function).withLogLevel(.trace)
-        ) { sub in
+        try await withTestSubscription(subscribeInfos: [.init(topicFilter: "testTopic", qos: .atMostOnce)]) { sub in
             var iterator = sub.makeAsyncIterator()
             let event = try #require(try await iterator.next())
             #expect(event.payload == ByteBuffer(string: "TestPayload"))
@@ -108,10 +103,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testSubscribeAndPublishQoS1() async throws {
-        try await withTestSubscription(
-            subscribeInfos: [.init(topicFilter: "testTopic", qos: .atLeastOnce)],
-            logger: Logger(label: #function).withLogLevel(.trace)
-        ) { sub in
+        try await withTestSubscription(subscribeInfos: [.init(topicFilter: "testTopic", qos: .atLeastOnce)]) { sub in
             var iterator = sub.makeAsyncIterator()
             let event = try #require(try await iterator.next())
             #expect(event.payload == ByteBuffer(string: "TestPayload"))
@@ -138,10 +130,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testSubscribeAndPublishQoS2() async throws {
-        try await withTestSubscription(
-            subscribeInfos: [.init(topicFilter: "testTopic", qos: .exactlyOnce)],
-            logger: Logger(label: #function).withLogLevel(.trace)
-        ) { sub in
+        try await withTestSubscription(subscribeInfos: [.init(topicFilter: "testTopic", qos: .exactlyOnce)]) { sub in
             var iterator = sub.makeAsyncIterator()
             let event = try #require(try await iterator.next())
             #expect(event.payload == ByteBuffer(string: "TestPayload"))
@@ -176,10 +165,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testSubscribeAndDuplicatePublishQoS2() async throws {
-        try await withTestSubscription(
-            subscribeInfos: [.init(topicFilter: "testTopic", qos: .exactlyOnce)],
-            logger: Logger(label: #function).withLogLevel(.trace)
-        ) { sub in
+        try await withTestSubscription(subscribeInfos: [.init(topicFilter: "testTopic", qos: .exactlyOnce)]) { sub in
             var iterator = sub.makeAsyncIterator()
             let event = try #require(try await iterator.next())
             #expect(event.payload == ByteBuffer(string: "TestPayload"))
@@ -232,10 +218,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testTopicFilter() async throws {
-        try await withTestSubscription(
-            subscribeInfos: [.init(topicFilter: "testTopic/+", qos: .atMostOnce)],
-            logger: Logger(label: #function).withLogLevel(.trace)
-        ) { sub in
+        try await withTestSubscription(subscribeInfos: [.init(topicFilter: "testTopic/+", qos: .atMostOnce)]) { sub in
             var iterator = sub.makeAsyncIterator()
             let event = try #require(try await iterator.next())
             #expect(event.payload == ByteBuffer(string: "TestPayload2"))
@@ -270,10 +253,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testSubscriptionIdFilter() async throws {
-        try await withTestV5Subscription(
-            subscribeInfos: [.init(topicFilter: "testTopic/+", qos: .atMostOnce)],
-            logger: Logger(label: #function).withLogLevel(.trace)
-        ) { sub in
+        try await withTestV5Subscription(subscribeInfos: [.init(topicFilter: "testTopic/+", qos: .atMostOnce)]) { sub in
             var iterator = sub.makeAsyncIterator()
             let event = try #require(try await iterator.next())
             #expect(event.payload == ByteBuffer(string: "TestPayload2"))
@@ -314,66 +294,64 @@ struct MQTTConnectionTests {
             .init(topicFilter: "test/topic", qos: .atMostOnce),
         ]
 
-        try await withLogger(Logger(label: #function).withLogLevel(.trace)) { _ in
-            try await withTestMQTTServer(configuration: .init(versionConfiguration: .v5_0())) { connection in
-                try await withThrowingTaskGroup { group in
-                    for subscribeInfo in subscribeInfos {
-                        group.addTask {
-                            try await connection.subscribe(to: [subscribeInfo]) { subscription in
-                                var iterator = subscription.makeAsyncIterator()
-                                _ = try #require(try await iterator.next())
-                            }
+        try await withTestMQTTServer(configuration: .init(versionConfiguration: .v5_0())) { connection in
+            try await withThrowingTaskGroup { group in
+                for subscribeInfo in subscribeInfos {
+                    group.addTask {
+                        try await connection.subscribe(to: [subscribeInfo]) { subscription in
+                            var iterator = subscription.makeAsyncIterator()
+                            _ = try #require(try await iterator.next())
                         }
                     }
-                    try await group.waitForAll()
                 }
-            } server: { channel in
-                var subscriptionIds: [UInt32] = []
-                for _ in subscribeInfos {
-                    // receive SUBSCRIBE
-                    let packet = try await channel.waitForOutboundPacket()
-                    let subscribePacket = try MQTTSubscribePacket.read(version: .v5_0, from: packet)
-                    // collect Subscription Identifier
-                    let properties = try #require(subscribePacket.properties)
-                    let subscriptionId: UInt32 = try #require(
-                        {
-                            for property in properties {
-                                if case .subscriptionIdentifier(let id) = property {
-                                    return id
-                                }
+                try await group.waitForAll()
+            }
+        } server: { channel in
+            var subscriptionIds: [UInt32] = []
+            for _ in subscribeInfos {
+                // receive SUBSCRIBE
+                let packet = try await channel.waitForOutboundPacket()
+                let subscribePacket = try MQTTSubscribePacket.read(version: .v5_0, from: packet)
+                // collect Subscription Identifier
+                let properties = try #require(subscribePacket.properties)
+                let subscriptionId: UInt32 = try #require(
+                    {
+                        for property in properties {
+                            if case .subscriptionIdentifier(let id) = property {
+                                return id
                             }
-                            return nil
-                        }()
-                    )
-                    subscriptionIds.append(subscriptionId)
-                    // send SUBACK
-                    let suback = MQTTSubAckPacket(type: .SUBACK, packetId: subscribePacket.packetId, reasons: [.success])
-                    try await channel.writeInboundPacket(suback, version: .v5_0)
-                }
-                try #require(subscriptionIds.count == subscribeInfos.count)
-
-                // send PUBLISH
-                let publish = MQTTPublishPacket(
-                    publish: .init(
-                        qos: .atMostOnce,
-                        retain: false,
-                        topicName: "wrongTopic/usesSubIDs",
-                        payload: ByteBuffer(string: "TestPayload2"),
-                        // Multiple Subscription Identifiers will be included if the publication is the result of a match to more than one subscription
-                        properties: .init(subscriptionIds.map { .subscriptionIdentifier($0) })
-                    ),
-                    packetId: 32769
+                        }
+                        return nil
+                    }()
                 )
-                try await channel.writeInboundPacket(publish, version: .v5_0)
+                subscriptionIds.append(subscriptionId)
+                // send SUBACK
+                let suback = MQTTSubAckPacket(type: .SUBACK, packetId: subscribePacket.packetId, reasons: [.success])
+                try await channel.writeInboundPacket(suback, version: .v5_0)
+            }
+            try #require(subscriptionIds.count == subscribeInfos.count)
 
-                for _ in subscribeInfos {
-                    // receive UNSUBSCRIBE
-                    let packet = try await channel.waitForOutboundPacket()
-                    let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v5_0, from: packet)
-                    // send SUBACK
-                    let unsuback = MQTTSubAckPacket(type: .UNSUBACK, packetId: unsubscribePacket.packetId, reasons: [.success])
-                    try await channel.writeInboundPacket(unsuback, version: .v5_0)
-                }
+            // send PUBLISH
+            let publish = MQTTPublishPacket(
+                publish: .init(
+                    qos: .atMostOnce,
+                    retain: false,
+                    topicName: "wrongTopic/usesSubIDs",
+                    payload: ByteBuffer(string: "TestPayload2"),
+                    // Multiple Subscription Identifiers will be included if the publication is the result of a match to more than one subscription
+                    properties: .init(subscriptionIds.map { .subscriptionIdentifier($0) })
+                ),
+                packetId: 32769
+            )
+            try await channel.writeInboundPacket(publish, version: .v5_0)
+
+            for _ in subscribeInfos {
+                // receive UNSUBSCRIBE
+                let packet = try await channel.waitForOutboundPacket()
+                let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v5_0, from: packet)
+                // send SUBACK
+                let unsuback = MQTTSubAckPacket(type: .UNSUBACK, packetId: unsubscribePacket.packetId, reasons: [.success])
+                try await channel.writeInboundPacket(unsuback, version: .v5_0)
             }
         }
     }
@@ -384,8 +362,7 @@ struct MQTTConnectionTests {
         let connection = try await MQTTConnection.setupChannelAndConnect(
             channel,
             configuration: .init(versionConfiguration: .v5_0(authWorkflow: SimpleAuthWorkflow())),
-            session: MQTTSessionStorage(clientID: "", logger: Logger(label: #function).withLogLevel(.trace)),
-            logger: Logger(label: #function).withLogLevel(.trace)
+            session: MQTTSessionStorage(clientID: "", logger: Logger.current)
         )
         return try await withThrowingTaskGroup { group in
             group.addTask {
@@ -421,10 +398,7 @@ struct MQTTConnectionTests {
 
     @Test
     func testReAuthenticate() async throws {
-        try await withTestMQTTServer(
-            configuration: .init(versionConfiguration: .v5_0(authWorkflow: SimpleAuthWorkflow())),
-            logger: Logger(label: #function).withLogLevel(.trace)
-        ) { connection in
+        try await withTestMQTTServer(configuration: .init(versionConfiguration: .v5_0(authWorkflow: SimpleAuthWorkflow()))) { connection in
             _ = try await connection.v5.auth(properties: [])
         } server: { channel in
             // wait for auth
@@ -451,7 +425,7 @@ struct MQTTConnectionTests {
     @Test("Cancellation")
     func cancellation() async throws {
         let (stream, cont) = AsyncStream.makeStream(of: Void.self)
-        try await withTestMQTTServer(logger: Logger(label: #function).withLogLevel(.trace)) { connection in
+        try await withTestMQTTServer { connection in
             await withThrowingTaskGroup { group in
                 group.addTask {
                     await #expect(throws: MQTTError.cancelled) {
@@ -469,8 +443,7 @@ struct MQTTConnectionTests {
 
     @Test("Inflight")
     func inflight() async throws {
-        let logger = Logger(label: #function).withLogLevel(.trace)
-        let session = MQTTSession(clientID: "inflight", logger: logger)
+        let session = MQTTSession(clientID: "inflight")
 
         // This stream is used to pass the PUBLISH packet ID from the first server to the second
         let (publishPacketIDStream, publishPacketIDCont) = AsyncStream.makeStream(of: UInt16.self)
@@ -478,7 +451,7 @@ struct MQTTConnectionTests {
         // This stream is used to make the connection wait to close until the server has finished processing
         let (stream, cont) = AsyncStream.makeStream(of: Void.self)
 
-        try await withTestMQTTServer(session: session, logger: logger) { connection in
+        try await withTestMQTTServer(session: session) { connection in
             async let _ = connection.publish(to: "testTopic", payload: ByteBuffer(string: "TestPayload"), qos: .exactlyOnce)
             await stream.first { _ in true }
             connection.close()
@@ -510,7 +483,7 @@ struct MQTTConnectionTests {
 
         #expect(try session.storage.borrow { $0.inflight.packets.count > 0 })
 
-        try await withTestMQTTServer(session: session, logger: logger) { _ in
+        try await withTestMQTTServer(session: session) { _ in
             await stream.first { _ in true }
         } server: { channel in
             // Read PUBREL
@@ -534,11 +507,8 @@ struct MQTTConnectionTests {
 
     @Test("Maximum Packet Size", arguments: MQTTQoS.allCases)
     func maximumPacketSize(qos: MQTTQoS) async throws {
-        let logger = Logger(label: #function).withLogLevel(.trace)
-
         try await withTestMQTTServer(
             configuration: .init(versionConfiguration: .v5_0()),
-            logger: logger,
             connackProperties: [.maximumPacketSize(50)]
         ) { connection in
             await #expect(throws: MQTTError.packetTooLarge) {
@@ -588,31 +558,29 @@ struct MQTTConnectionTests {
 
     @Test("Subscription with Session")
     func subscriptionWithSession() async throws {
-        try await withLogger(Logger(label: #function).withLogLevel(.trace)) { _ in
-            try await withTestSessionSubscription(to: [.init(topicFilter: "testTopic", qos: .atLeastOnce)]) { subscription in
-                var iterator = subscription.makeAsyncIterator()
-                let event = try #require(try await iterator.next())
-                #expect(event.payload == ByteBuffer(string: "TestPayload"))
-            } client: { _ in
-            } server: { channel in
-                // Send PUBLISH
-                let publish = MQTTPublishPacket(
-                    publish: .init(
-                        qos: .atLeastOnce,
-                        retain: false,
-                        topicName: "testTopic",
-                        payload: ByteBuffer(string: "TestPayload"),
-                        properties: .init()
-                    ),
-                    packetId: 32768
-                )
-                try await channel.writeInboundPacket(publish, version: .v3_1_1)
-                // Read PUBACK
-                let publishPacket = try await channel.waitForOutboundPacket()
-                let pubAck = try MQTTPubAckPacket.read(version: .v3_1_1, from: publishPacket)
-                #expect(pubAck.type == .PUBACK)
-                #expect(pubAck.packetId == publish.packetId)
-            }
+        try await withTestSessionSubscription(to: [.init(topicFilter: "testTopic", qos: .atLeastOnce)]) { subscription in
+            var iterator = subscription.makeAsyncIterator()
+            let event = try #require(try await iterator.next())
+            #expect(event.payload == ByteBuffer(string: "TestPayload"))
+        } client: { _ in
+        } server: { channel in
+            // Send PUBLISH
+            let publish = MQTTPublishPacket(
+                publish: .init(
+                    qos: .atLeastOnce,
+                    retain: false,
+                    topicName: "testTopic",
+                    payload: ByteBuffer(string: "TestPayload"),
+                    properties: .init()
+                ),
+                packetId: 32768
+            )
+            try await channel.writeInboundPacket(publish, version: .v3_1_1)
+            // Read PUBACK
+            let publishPacket = try await channel.waitForOutboundPacket()
+            let pubAck = try MQTTPubAckPacket.read(version: .v3_1_1, from: publishPacket)
+            #expect(pubAck.type == .PUBACK)
+            #expect(pubAck.packetId == publish.packetId)
         }
     }
 
@@ -624,40 +592,36 @@ struct MQTTConnectionTests {
             [.init(topicFilter: "testTopic3", qos: .atMostOnce)],
         ]
 
-        try await withLogger(Logger(label: #function).withLogLevel(.trace)) { _ in
-            try await withTestSessionSubscriptions(to: subscribeInfos) { subscription in
-                var iterator = subscription.makeAsyncIterator()
-                let event = try #require(try await iterator.next())
-                #expect(event.payload == ByteBuffer(string: "TestPayload"))
-            } client: { connection in
-                try await connection.waitUntilNoActiveSubscriptions()
-            } server: { channel in
-                for subscribeInfo in subscribeInfos {
-                    // Send PUBLISH
-                    let publish = MQTTPublishPacket(
-                        publish: .init(
-                            qos: .atMostOnce,
-                            retain: false,
-                            topicName: subscribeInfo.first!.topicFilter,
-                            payload: ByteBuffer(string: "TestPayload"),
-                            properties: .init()
-                        ),
-                        packetId: 32768
-                    )
-                    try await channel.writeInboundPacket(publish, version: .v3_1_1)
-                }
+        try await withTestSessionSubscriptions(to: subscribeInfos) { subscription in
+            var iterator = subscription.makeAsyncIterator()
+            let event = try #require(try await iterator.next())
+            #expect(event.payload == ByteBuffer(string: "TestPayload"))
+        } client: { connection in
+            try await connection.waitUntilNoActiveSubscriptions()
+        } server: { channel in
+            for subscribeInfo in subscribeInfos {
+                // Send PUBLISH
+                let publish = MQTTPublishPacket(
+                    publish: .init(
+                        qos: .atMostOnce,
+                        retain: false,
+                        topicName: subscribeInfo.first!.topicFilter,
+                        payload: ByteBuffer(string: "TestPayload"),
+                        properties: .init()
+                    ),
+                    packetId: 32768
+                )
+                try await channel.writeInboundPacket(publish, version: .v3_1_1)
             }
         }
     }
 
     @Test("Wait with No Active Subscriptions")
     func waitWithNoActiveSubscriptions() async throws {
-        try await withLogger(Logger(label: #function).withLogLevel(.trace)) { _ in
-            try await withTestMQTTServer { connection in
-                // Should return immediately as there are no active subscriptions
-                try await connection.waitUntilNoActiveSubscriptions()
-            } server: { _ in
-            }
+        try await withTestMQTTServer { connection in
+            // Should return immediately as there are no active subscriptions
+            try await connection.waitUntilNoActiveSubscriptions()
+        } server: { _ in
         }
     }
 }

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -18,8 +18,10 @@ import Testing
 struct MQTTConnectionTests {
     @Test
     func testConnectDisconnect() async throws {
-        try await withTestMQTTServer(logger: Logger(label: #function).withLogLevel(.trace)) { _ in
-        } server: { _ in
+        try await withLogger(Logger(label: #function).withLogLevel(.trace)) { _ in
+            try await withTestMQTTServer { _ in
+            } server: { _ in
+            }
         }
     }
 
@@ -312,67 +314,66 @@ struct MQTTConnectionTests {
             .init(topicFilter: "test/topic", qos: .atMostOnce),
         ]
 
-        try await withTestMQTTServer(
-            configuration: .init(versionConfiguration: .v5_0()),
-            logger: Logger(label: #function).withLogLevel(.trace)
-        ) { connection in
-            try await withThrowingTaskGroup { group in
-                for subscribeInfo in subscribeInfos {
-                    group.addTask {
-                        try await connection.subscribe(to: [subscribeInfo]) { subscription in
-                            var iterator = subscription.makeAsyncIterator()
-                            _ = try #require(try await iterator.next())
-                        }
-                    }
-                }
-                try await group.waitForAll()
-            }
-        } server: { channel in
-            var subscriptionIds: [UInt32] = []
-            for _ in subscribeInfos {
-                // receive SUBSCRIBE
-                let packet = try await channel.waitForOutboundPacket()
-                let subscribePacket = try MQTTSubscribePacket.read(version: .v5_0, from: packet)
-                // collect Subscription Identifier
-                let properties = try #require(subscribePacket.properties)
-                let subscriptionId: UInt32 = try #require(
-                    {
-                        for property in properties {
-                            if case .subscriptionIdentifier(let id) = property {
-                                return id
+        try await withLogger(Logger(label: #function).withLogLevel(.trace)) { _ in
+            try await withTestMQTTServer(configuration: .init(versionConfiguration: .v5_0())) { connection in
+                try await withThrowingTaskGroup { group in
+                    for subscribeInfo in subscribeInfos {
+                        group.addTask {
+                            try await connection.subscribe(to: [subscribeInfo]) { subscription in
+                                var iterator = subscription.makeAsyncIterator()
+                                _ = try #require(try await iterator.next())
                             }
                         }
-                        return nil
-                    }()
+                    }
+                    try await group.waitForAll()
+                }
+            } server: { channel in
+                var subscriptionIds: [UInt32] = []
+                for _ in subscribeInfos {
+                    // receive SUBSCRIBE
+                    let packet = try await channel.waitForOutboundPacket()
+                    let subscribePacket = try MQTTSubscribePacket.read(version: .v5_0, from: packet)
+                    // collect Subscription Identifier
+                    let properties = try #require(subscribePacket.properties)
+                    let subscriptionId: UInt32 = try #require(
+                        {
+                            for property in properties {
+                                if case .subscriptionIdentifier(let id) = property {
+                                    return id
+                                }
+                            }
+                            return nil
+                        }()
+                    )
+                    subscriptionIds.append(subscriptionId)
+                    // send SUBACK
+                    let suback = MQTTSubAckPacket(type: .SUBACK, packetId: subscribePacket.packetId, reasons: [.success])
+                    try await channel.writeInboundPacket(suback, version: .v5_0)
+                }
+                try #require(subscriptionIds.count == subscribeInfos.count)
+
+                // send PUBLISH
+                let publish = MQTTPublishPacket(
+                    publish: .init(
+                        qos: .atMostOnce,
+                        retain: false,
+                        topicName: "wrongTopic/usesSubIDs",
+                        payload: ByteBuffer(string: "TestPayload2"),
+                        // Multiple Subscription Identifiers will be included if the publication is the result of a match to more than one subscription
+                        properties: .init(subscriptionIds.map { .subscriptionIdentifier($0) })
+                    ),
+                    packetId: 32769
                 )
-                subscriptionIds.append(subscriptionId)
-                // send SUBACK
-                let suback = MQTTSubAckPacket(type: .SUBACK, packetId: subscribePacket.packetId, reasons: [.success])
-                try await channel.writeInboundPacket(suback, version: .v5_0)
-            }
-            try #require(subscriptionIds.count == subscribeInfos.count)
+                try await channel.writeInboundPacket(publish, version: .v5_0)
 
-            // send PUBLISH
-            let publish = MQTTPublishPacket(
-                publish: .init(
-                    qos: .atMostOnce,
-                    retain: false,
-                    topicName: "wrongTopic/usesSubIDs",
-                    payload: ByteBuffer(string: "TestPayload2"),
-                    // Multiple Subscription Identifiers will be included if the publication is the result of a match to more than one subscription
-                    properties: .init(subscriptionIds.map { .subscriptionIdentifier($0) })
-                ),
-                packetId: 32769
-            )
-            try await channel.writeInboundPacket(publish, version: .v5_0)
-
-            for _ in subscribeInfos {
-                // receive UNSUBSCRIBE
-                let packet = try await channel.waitForOutboundPacket()
-                let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v5_0, from: packet)
-                // send SUBACK
-                let unsuback = MQTTSubAckPacket(type: .UNSUBACK, packetId: unsubscribePacket.packetId, reasons: [.success])
-                try await channel.writeInboundPacket(unsuback, version: .v5_0)
+                for _ in subscribeInfos {
+                    // receive UNSUBSCRIBE
+                    let packet = try await channel.waitForOutboundPacket()
+                    let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v5_0, from: packet)
+                    // send SUBACK
+                    let unsuback = MQTTSubAckPacket(type: .UNSUBACK, packetId: unsubscribePacket.packetId, reasons: [.success])
+                    try await channel.writeInboundPacket(unsuback, version: .v5_0)
+                }
             }
         }
     }
@@ -587,36 +588,36 @@ struct MQTTConnectionTests {
 
     @Test("Subscription with Session")
     func subscriptionWithSession() async throws {
-        let logger = Logger(label: #function).withLogLevel(.trace)
-        let session = MQTTSession(clientID: "subscriptionWithSession", logger: logger)
+        try await withLogger(Logger(label: #function).withLogLevel(.trace)) { _ in
+            let session = MQTTSession(clientID: "subscriptionWithSession")
 
-        try await withTestSessionSubscription(
-            to: [.init(topicFilter: "testTopic", qos: .atLeastOnce)],
-            session: session,
-            logger: logger
-        ) { subscription in
-            var iterator = subscription.makeAsyncIterator()
-            let event = try #require(try await iterator.next())
-            #expect(event.payload == ByteBuffer(string: "TestPayload"))
-        } client: { _ in
-        } server: { channel in
-            // Send PUBLISH
-            let publish = MQTTPublishPacket(
-                publish: .init(
-                    qos: .atLeastOnce,
-                    retain: false,
-                    topicName: "testTopic",
-                    payload: ByteBuffer(string: "TestPayload"),
-                    properties: .init()
-                ),
-                packetId: 32768
-            )
-            try await channel.writeInboundPacket(publish, version: .v3_1_1)
-            // Read PUBACK
-            let publishPacket = try await channel.waitForOutboundPacket()
-            let pubAck = try MQTTPubAckPacket.read(version: .v3_1_1, from: publishPacket)
-            #expect(pubAck.type == .PUBACK)
-            #expect(pubAck.packetId == publish.packetId)
+            try await withTestSessionSubscription(
+                to: [.init(topicFilter: "testTopic", qos: .atLeastOnce)],
+                session: session
+            ) { subscription in
+                var iterator = subscription.makeAsyncIterator()
+                let event = try #require(try await iterator.next())
+                #expect(event.payload == ByteBuffer(string: "TestPayload"))
+            } client: { _ in
+            } server: { channel in
+                // Send PUBLISH
+                let publish = MQTTPublishPacket(
+                    publish: .init(
+                        qos: .atLeastOnce,
+                        retain: false,
+                        topicName: "testTopic",
+                        payload: ByteBuffer(string: "TestPayload"),
+                        properties: .init()
+                    ),
+                    packetId: 32768
+                )
+                try await channel.writeInboundPacket(publish, version: .v3_1_1)
+                // Read PUBACK
+                let publishPacket = try await channel.waitForOutboundPacket()
+                let pubAck = try MQTTPubAckPacket.read(version: .v3_1_1, from: publishPacket)
+                #expect(pubAck.type == .PUBACK)
+                #expect(pubAck.packetId == publish.packetId)
+            }
         }
     }
 

--- a/Tests/MQTTNIOTests/Utils/Logger+withLogLevel.swift
+++ b/Tests/MQTTNIOTests/Utils/Logger+withLogLevel.swift
@@ -18,6 +18,8 @@ extension Logger {
 }
 
 struct DefaultLoggerTrait: TestTrait, SuiteTrait, TestScoping {
+    let logLevel: Logger.Level
+
     var isRecursive: Bool { true }
 
     func provideScope(
@@ -25,7 +27,7 @@ struct DefaultLoggerTrait: TestTrait, SuiteTrait, TestScoping {
         testCase: Test.Case?,
         performing function: @concurrent @Sendable () async throws -> Void
     ) async throws {
-        try await withLogger(Logger(label: test.displayName ?? test.name).withLogLevel(.trace)) { _ in
+        try await withLogger(Logger(label: test.displayName ?? test.name).withLogLevel(logLevel)) { _ in
             try await function()
         }
     }
@@ -34,6 +36,6 @@ struct DefaultLoggerTrait: TestTrait, SuiteTrait, TestScoping {
 extension Trait where Self == DefaultLoggerTrait {
     /// A trait that provides a default task-local `Logger` for all tests and suites.
     ///
-    /// The logger is configured with a log level of `trace` and a label that corresponds to the test display name.
-    static var defaultLogger: Self { Self() }
+    /// The logger is configured with the provided log level and a label that corresponds to the test display name.
+    static func defaultLogger(logLevel: Logger.Level) -> Self { Self(logLevel: logLevel) }
 }

--- a/Tests/MQTTNIOTests/Utils/Logger+withLogLevel.swift
+++ b/Tests/MQTTNIOTests/Utils/Logger+withLogLevel.swift
@@ -7,6 +7,7 @@
 //
 
 import Logging
+import Testing
 
 extension Logger {
     func withLogLevel(_ logLevel: Logger.Level) -> Logger {
@@ -14,4 +15,25 @@ extension Logger {
         logger.logLevel = logLevel
         return logger
     }
+}
+
+struct DefaultLoggerTrait: TestTrait, SuiteTrait, TestScoping {
+    var isRecursive: Bool { true }
+
+    func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: @concurrent @Sendable () async throws -> Void
+    ) async throws {
+        try await withLogger(Logger(label: test.displayName ?? test.name).withLogLevel(.trace)) { _ in
+            try await function()
+        }
+    }
+}
+
+extension Trait where Self == DefaultLoggerTrait {
+    /// A trait that provides a default task-local `Logger` for all tests and suites.
+    ///
+    /// The logger is configured with a log level of `trace` and a label that corresponds to the test display name.
+    static var defaultLogger: Self { Self() }
 }

--- a/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
+++ b/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import Logging
 import NIOCore
 import NIOEmbedded
 import Testing
@@ -23,7 +22,6 @@ extension MQTTConnectionTests {
     /// - Parameters:
     ///   - configuration: The configuration to use for the MQTT connection.
     ///   - session: The MQTT session to use for the connection.
-    ///   - logger: The logger to use for logging MQTT events. Defaults to the current task-local logger.
     ///   - connackProperties: The properties to include in the CONNACK packet.
     ///   - clientOperation: An async operation to perform for the client side of the test.
     ///         The ``MQTTConnection`` will be passed as a parameter to this operation.
@@ -32,7 +30,6 @@ extension MQTTConnectionTests {
     func withTestMQTTServer(
         configuration: MQTTConnectionConfiguration = .init(),
         session: MQTTSession = MQTTSession(clientID: ""),
-        logger: Logger = Logger.current,
         connackProperties: MQTTProperties = .init(),
         client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void,
@@ -45,8 +42,7 @@ extension MQTTConnectionTests {
                     connection = try await MQTTConnection.setupChannelAndConnect(
                         channel,
                         configuration: configuration,
-                        session: sessionStorage,
-                        logger: logger
+                        session: sessionStorage
                     )
                 } catch {
                     return (sessionStorage, .failure(error))
@@ -114,18 +110,16 @@ extension MQTTConnectionTests {
     ///
     /// - Parameters:
     ///   - subscribeInfos: An array of ``MQTTSubscribeInfo`` to subscribe to for this subscription.
-    ///   - logger: The logger to use for the test MQTT server. Defaults to the current task-local logger.
     ///   - clientOperation: An async operation to perform for the subscription opened via the connection.
     ///         The opened subscription will be passed as a parameter to this operation.
     ///   - serverOperation: An async operation to perform for the subscription on the server side.
     ///         The test MQTT server channel will be passed as a parameter to this operation.
     func withTestSubscription(
         subscribeInfos: [MQTTSubscribeInfo],
-        logger: Logger = Logger.current,
         client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void,
     ) async throws {
-        try await withTestMQTTServer(logger: logger) { connection in
+        try await withTestMQTTServer { connection in
             try await connection.subscribe(to: subscribeInfos) { sub in
                 try await clientOperation(sub)
             }
@@ -168,7 +162,6 @@ extension MQTTConnectionTests {
     ///
     /// - Parameters:
     ///   - subscribeInfos: An array of ``MQTTSubscribeInfoV5`` to subscribe to for this subscription.
-    ///   - logger: The logger to use for the test MQTT server. Defaults to the current task-local logger.
     ///   - clientOperation: An async operation to perform for the subscription opened via the connection.
     ///         The opened subscription will be passed as a parameter to this operation.
     ///   - serverOperation: An async operation to perform for the subscription on the server side.
@@ -176,11 +169,10 @@ extension MQTTConnectionTests {
     ///         The subscription identifier will also be passed as a parameter.
     func withTestV5Subscription(
         subscribeInfos: [MQTTSubscribeInfoV5],
-        logger: Logger = Logger.current,
         client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel, UInt32) async throws -> Void,
     ) async throws {
-        try await withTestMQTTServer(configuration: .init(versionConfiguration: .v5_0()), logger: logger) { connection in
+        try await withTestMQTTServer(configuration: .init(versionConfiguration: .v5_0())) { connection in
             try await connection.v5.subscribe(to: subscribeInfos) { sub in
                 try await clientOperation(sub)
             }
@@ -238,7 +230,6 @@ extension MQTTConnectionTests {
     /// - Parameters:
     ///   - subscribeInfos: An array of arrays of ``MQTTSubscribeInfoV5`` to subscribe to.
     ///         Each inner array represents a separate subscription.
-    ///   - logger: The logger to use for the test MQTT server. Defaults to the current task-local logger.
     ///   - subscribeOperation: An async operation to perform for each subscription opened via the session.
     ///         The opened subscription will be passed as a parameter to this operation.
     ///   - clientOperation: An async operation to perform for the client side of the test.
@@ -247,14 +238,13 @@ extension MQTTConnectionTests {
     ///         The test MQTT server channel will be passed as a parameter to this operation.
     func withTestSessionSubscriptions(
         to subscribeInfos: [[MQTTSubscribeInfoV5]],
-        logger: Logger = Logger.current,
         subscribe subscribeOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
         client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
     ) async throws {
-        let session = MQTTSession(clientID: UUID().uuidString, logger: logger)
+        let session = MQTTSession(clientID: UUID().uuidString)
         let (stream, cont) = AsyncStream.makeStream(of: Void.self)
-        try await withTestMQTTServer(session: session, logger: logger) { connection in
+        try await withTestMQTTServer(session: session) { connection in
             try await withThrowingTaskGroup { group in
                 for subscribeInfo in subscribeInfos {
                     group.addTask {
@@ -305,7 +295,6 @@ extension MQTTConnectionTests {
     ///
     /// - Parameters:
     ///   - subscribeInfos: An array of ``MQTTSubscribeInfoV5`` to subscribe to for this subscription.
-    ///   - logger: The logger to use for the test MQTT server. Defaults to the current task-local logger.
     ///   - subscribeOperation: An async operation to perform for the subscription opened via the session.
     ///         The opened subscription will be passed as a parameter to this operation.
     ///   - clientOperation: An async operation to perform for the client side of the test.
@@ -314,14 +303,12 @@ extension MQTTConnectionTests {
     ///         The test MQTT server channel will be passed as a parameter to this operation.
     func withTestSessionSubscription(
         to subscribeInfos: [MQTTSubscribeInfoV5],
-        logger: Logger = Logger.current,
         subscribe subscribeOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
         client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
     ) async throws {
         try await withTestSessionSubscriptions(
             to: [subscribeInfos],
-            logger: logger,
             subscribe: subscribeOperation,
             client: clientOperation,
             server: serverOperation

--- a/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
+++ b/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
@@ -23,7 +23,7 @@ extension MQTTConnectionTests {
     /// - Parameters:
     ///   - configuration: The configuration to use for the MQTT connection.
     ///   - session: The MQTT session to use for the connection.
-    ///   - logger: The logger to use for logging MQTT events.
+    ///   - logger: The logger to use for logging MQTT events. Defaults to the current task-local logger.
     ///   - connackProperties: The properties to include in the CONNACK packet.
     ///   - clientOperation: An async operation to perform for the client side of the test.
     ///         The ``MQTTConnection`` will be passed as a parameter to this operation.
@@ -31,8 +31,8 @@ extension MQTTConnectionTests {
     ///         The test MQTT server channel will be passed as a parameter to this operation.
     func withTestMQTTServer(
         configuration: MQTTConnectionConfiguration = .init(),
-        session: MQTTSession = MQTTSession(clientID: "", logger: Logger(label: "test_session")),
-        logger: Logger,
+        session: MQTTSession = MQTTSession(clientID: ""),
+        logger: Logger = Logger.current,
         connackProperties: MQTTProperties = .init(),
         client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void,
@@ -116,7 +116,7 @@ extension MQTTConnectionTests {
     ///   - subscribeInfos: An array of ``MQTTSubscribeInfo`` to subscribe to for this subscription.
     ///   - cleanSession: Whether to use a clean session for the connection.
     ///   - identifier: The client identifier to use for the connection. If not provided, a random UUID string will be used.
-    ///   - logger: The logger to use for the test MQTT server.
+    ///   - logger: The logger to use for the test MQTT server. Defaults to the current task-local logger.
     ///   - clientOperation: An async operation to perform for the subscription opened via the connection.
     ///         The opened subscription will be passed as a parameter to this operation.
     ///   - serverOperation: An async operation to perform for the subscription on the server side.
@@ -125,7 +125,7 @@ extension MQTTConnectionTests {
         subscribeInfos: [MQTTSubscribeInfo],
         cleanSession: Bool = true,
         identifier: String = UUID().uuidString,
-        logger: Logger,
+        logger: Logger = Logger.current,
         client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void,
     ) async throws {
@@ -174,7 +174,7 @@ extension MQTTConnectionTests {
     ///   - subscribeInfos: An array of ``MQTTSubscribeInfoV5`` to subscribe to for this subscription.
     ///   - cleanSession: Whether to use a clean session for the connection.
     ///   - identifier: The client identifier to use for the connection. If not provided, a random UUID string will be used.
-    ///   - logger: The logger to use for the test MQTT server.
+    ///   - logger: The logger to use for the test MQTT server. Defaults to the current task-local logger.
     ///   - clientOperation: An async operation to perform for the subscription opened via the connection.
     ///         The opened subscription will be passed as a parameter to this operation.
     ///   - serverOperation: An async operation to perform for the subscription on the server side.
@@ -184,7 +184,7 @@ extension MQTTConnectionTests {
         subscribeInfos: [MQTTSubscribeInfoV5],
         cleanSession: Bool = true,
         identifier: String = UUID().uuidString,
-        logger: Logger,
+        logger: Logger = Logger.current,
         client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel, UInt32) async throws -> Void,
     ) async throws {
@@ -247,7 +247,7 @@ extension MQTTConnectionTests {
     ///   - subscribeInfos: An array of arrays of ``MQTTSubscribeInfoV5`` to subscribe to.
     ///         Each inner array represents a separate subscription.
     ///   - session: The ``MQTTSession`` to use for opening the subscriptions.
-    ///   - logger: The logger to use for the test MQTT server.
+    ///   - logger: The logger to use for the test MQTT server. Defaults to the current task-local logger.
     ///   - subscribeOperation: An async operation to perform for each subscription opened via the session.
     ///         The opened subscription will be passed as a parameter to this operation.
     ///   - clientOperation: An async operation to perform for the client side of the test.
@@ -257,7 +257,7 @@ extension MQTTConnectionTests {
     func withTestSessionSubscriptions(
         to subscribeInfos: [[MQTTSubscribeInfoV5]],
         session: MQTTSession,
-        logger: Logger,
+        logger: Logger = Logger.current,
         subscribe subscribeOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
         client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
@@ -315,7 +315,7 @@ extension MQTTConnectionTests {
     /// - Parameters:
     ///   - subscribeInfos: An array of ``MQTTSubscribeInfoV5`` to subscribe to for this subscription.
     ///   - session: The ``MQTTSession`` to use for opening the subscription.
-    ///   - logger: The logger to use for the test MQTT server.
+    ///   - logger: The logger to use for the test MQTT server. Defaults to the current task-local logger.
     ///   - subscribeOperation: An async operation to perform for the subscription opened via the session.
     ///         The opened subscription will be passed as a parameter to this operation.
     ///   - clientOperation: An async operation to perform for the client side of the test.
@@ -325,7 +325,7 @@ extension MQTTConnectionTests {
     func withTestSessionSubscription(
         to subscribeInfos: [MQTTSubscribeInfoV5],
         session: MQTTSession,
-        logger: Logger,
+        logger: Logger = Logger.current,
         subscribe subscribeOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
         client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void

--- a/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
+++ b/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
@@ -114,8 +114,6 @@ extension MQTTConnectionTests {
     ///
     /// - Parameters:
     ///   - subscribeInfos: An array of ``MQTTSubscribeInfo`` to subscribe to for this subscription.
-    ///   - cleanSession: Whether to use a clean session for the connection.
-    ///   - identifier: The client identifier to use for the connection. If not provided, a random UUID string will be used.
     ///   - logger: The logger to use for the test MQTT server. Defaults to the current task-local logger.
     ///   - clientOperation: An async operation to perform for the subscription opened via the connection.
     ///         The opened subscription will be passed as a parameter to this operation.
@@ -123,8 +121,6 @@ extension MQTTConnectionTests {
     ///         The test MQTT server channel will be passed as a parameter to this operation.
     func withTestSubscription(
         subscribeInfos: [MQTTSubscribeInfo],
-        cleanSession: Bool = true,
-        identifier: String = UUID().uuidString,
         logger: Logger = Logger.current,
         client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void,
@@ -172,8 +168,6 @@ extension MQTTConnectionTests {
     ///
     /// - Parameters:
     ///   - subscribeInfos: An array of ``MQTTSubscribeInfoV5`` to subscribe to for this subscription.
-    ///   - cleanSession: Whether to use a clean session for the connection.
-    ///   - identifier: The client identifier to use for the connection. If not provided, a random UUID string will be used.
     ///   - logger: The logger to use for the test MQTT server. Defaults to the current task-local logger.
     ///   - clientOperation: An async operation to perform for the subscription opened via the connection.
     ///         The opened subscription will be passed as a parameter to this operation.
@@ -182,8 +176,6 @@ extension MQTTConnectionTests {
     ///         The subscription identifier will also be passed as a parameter.
     func withTestV5Subscription(
         subscribeInfos: [MQTTSubscribeInfoV5],
-        cleanSession: Bool = true,
-        identifier: String = UUID().uuidString,
         logger: Logger = Logger.current,
         client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel, UInt32) async throws -> Void,
@@ -246,7 +238,6 @@ extension MQTTConnectionTests {
     /// - Parameters:
     ///   - subscribeInfos: An array of arrays of ``MQTTSubscribeInfoV5`` to subscribe to.
     ///         Each inner array represents a separate subscription.
-    ///   - session: The ``MQTTSession`` to use for opening the subscriptions.
     ///   - logger: The logger to use for the test MQTT server. Defaults to the current task-local logger.
     ///   - subscribeOperation: An async operation to perform for each subscription opened via the session.
     ///         The opened subscription will be passed as a parameter to this operation.
@@ -256,12 +247,12 @@ extension MQTTConnectionTests {
     ///         The test MQTT server channel will be passed as a parameter to this operation.
     func withTestSessionSubscriptions(
         to subscribeInfos: [[MQTTSubscribeInfoV5]],
-        session: MQTTSession,
         logger: Logger = Logger.current,
         subscribe subscribeOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
         client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
         server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
     ) async throws {
+        let session = MQTTSession(clientID: UUID().uuidString, logger: logger)
         let (stream, cont) = AsyncStream.makeStream(of: Void.self)
         try await withTestMQTTServer(session: session, logger: logger) { connection in
             try await withThrowingTaskGroup { group in
@@ -314,7 +305,6 @@ extension MQTTConnectionTests {
     ///
     /// - Parameters:
     ///   - subscribeInfos: An array of ``MQTTSubscribeInfoV5`` to subscribe to for this subscription.
-    ///   - session: The ``MQTTSession`` to use for opening the subscription.
     ///   - logger: The logger to use for the test MQTT server. Defaults to the current task-local logger.
     ///   - subscribeOperation: An async operation to perform for the subscription opened via the session.
     ///         The opened subscription will be passed as a parameter to this operation.
@@ -324,7 +314,6 @@ extension MQTTConnectionTests {
     ///         The test MQTT server channel will be passed as a parameter to this operation.
     func withTestSessionSubscription(
         to subscribeInfos: [MQTTSubscribeInfoV5],
-        session: MQTTSession,
         logger: Logger = Logger.current,
         subscribe subscribeOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
         client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
@@ -332,7 +321,6 @@ extension MQTTConnectionTests {
     ) async throws {
         try await withTestSessionSubscriptions(
             to: [subscribeInfos],
-            session: session,
             logger: logger,
             subscribe: subscribeOperation,
             client: clientOperation,


### PR DESCRIPTION
- Use by default the task-local logger in `MQTTConnection.withConnection` and `MQTTSession.init`
- Add a custom scoping trait to tests to automatically set our custom logger in all tests
- Update documentation