### PR TITLE
Switch timeout from `scheduleTask` to `NIOScheduledCallbackHandler`

### DIFF
--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler+stateMachine.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler+stateMachine.swift
@@ -248,7 +248,7 @@ extension MQTTChannelHandler {
 
         @usableFromInline
         enum HitDeadlineAction {
-            case cancelTask(requestID: Int)
+            case cancelTasks(requestIDs: [Int])
             case reschedule(NIODeadline)
             case clearCallback
         }
@@ -259,9 +259,12 @@ extension MQTTChannelHandler {
             case .uninitialized:
                 preconditionFailure("Cannot cancel when uninitialized")
             case .initialized(let state):
-                if let timedOutTask = state.tasks.tasks.lazy.min(by: { $0.deadline < $1.deadline }), timedOutTask.deadline <= now {
+                let timedOutRequestIDs = state.tasks.tasks.lazy
+                    .filter { $0.deadline <= now }
+                    .map { $0.requestID }
+                if !timedOutRequestIDs.isEmpty {
                     self = .initialized(state)
-                    return .cancelTask(requestID: timedOutTask.requestID)
+                    return .cancelTasks(requestIDs: .init(timedOutRequestIDs))
                 }
                 if let earliestDeadline = state.tasks.tasks.lazy.map({ $0.deadline }).min() {
                     self = .initialized(state)

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler+stateMachine.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler+stateMachine.swift
@@ -78,7 +78,7 @@ extension MQTTChannelHandler {
                                 if self.tasks.isEmpty {
                                     .cancel
                                 } else {
-                                    if let earliestDeadline = self.tasks.map({ $0.deadline }).min() {
+                                    if let earliestDeadline = self.tasks.lazy.map({ $0.deadline }).min() {
                                         .reschedule(earliestDeadline)
                                     } else {
                                         .doNothing

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler+stateMachine.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler+stateMachine.swift
@@ -259,11 +259,11 @@ extension MQTTChannelHandler {
             case .uninitialized:
                 preconditionFailure("Cannot cancel when uninitialized")
             case .initialized(let state):
-                if let timedOutTask = state.tasks.tasks.min(by: { $0.deadline < $1.deadline }), timedOutTask.deadline <= now {
+                if let timedOutTask = state.tasks.tasks.lazy.min(by: { $0.deadline < $1.deadline }), timedOutTask.deadline <= now {
                     self = .initialized(state)
                     return .cancelTask(requestID: timedOutTask.requestID)
                 }
-                if let earliestDeadline = state.tasks.tasks.map({ $0.deadline }).min() {
+                if let earliestDeadline = state.tasks.tasks.lazy.map({ $0.deadline }).min() {
                     self = .initialized(state)
                     return .reschedule(earliestDeadline)
                 }
@@ -313,7 +313,7 @@ extension MQTTChannelHandler {
                     if state.tasks.tasks.isEmpty {
                         .cancel
                     } else {
-                        if let earliestDeadline = state.tasks.tasks.map({ $0.deadline }).min() {
+                        if let earliestDeadline = state.tasks.tasks.lazy.map({ $0.deadline }).min() {
                             .reschedule(earliestDeadline)
                         } else {
                             .doNothing

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler+stateMachine.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler+stateMachine.swift
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import NIOCore
+
 extension MQTTChannelHandler {
     @usableFromInline
     struct StateMachine<Context>: ~Copyable {
@@ -62,7 +64,7 @@ extension MQTTChannelHandler {
             }
 
             enum ProcessPacketAction {
-                case succeedTask(MQTTTask)
+                case succeedTask(MQTTTask, DeadlineCallbackAction)
                 case failTask(MQTTTask, any Error)
                 case unhandledTask
             }
@@ -72,7 +74,17 @@ extension MQTTChannelHandler {
                         // should this task respond to inbound packet
                         if try task.checkInbound(packet) {
                             self.remove(at: index)
-                            return .succeedTask(task)
+                            let deadlineCallback: DeadlineCallbackAction =
+                                if self.tasks.isEmpty {
+                                    .cancel
+                                } else {
+                                    if let earliestDeadline = self.tasks.map({ $0.deadline }).min() {
+                                        .reschedule(earliestDeadline)
+                                    } else {
+                                        .doNothing
+                                    }
+                                }
+                            return .succeedTask(task, deadlineCallback)
                         }
                     } catch {
                         self.remove(at: index)
@@ -141,12 +153,19 @@ extension MQTTChannelHandler {
         }
 
         @usableFromInline
+        enum DeadlineCallbackAction {
+            case cancel
+            case reschedule(NIODeadline)
+            case doNothing
+        }
+
+        @usableFromInline
         enum ReceivedPacketAction {
             /// .PUBLISH
             case respondAndReturn
             /// .CONNACK, .PUBACK, .PUBREC, .PUBCOMP, .SUBACK, .UNSUBACK, .PINGRESP, .AUTH
             /// .PUBREL
-            case succeedTask(MQTTTask)
+            case succeedTask(MQTTTask, DeadlineCallbackAction)
             /// checkInbound threw error
             case failTask(MQTTTask, any Error)
             /// process packets where no equivalent task was found
@@ -172,8 +191,8 @@ extension MQTTChannelHandler {
                         let action = state.tasks.processPacket(packet)
                         self = .initialized(state)
                         switch action {
-                        case .succeedTask(let task):
-                            return .succeedTask(task)
+                        case .succeedTask(let task, let deadlineCallback):
+                            return .succeedTask(task, deadlineCallback)
                         case .failTask(let task, let error):
                             return .failTask(task, error)
                         case .unhandledTask:
@@ -187,8 +206,8 @@ extension MQTTChannelHandler {
                     let action = state.tasks.processPacket(packet)
                     self = .initialized(state)
                     switch action {
-                    case .succeedTask(let task):
-                        return .succeedTask(task)
+                    case .succeedTask(let task, let deadlineCallback):
+                        return .succeedTask(task, deadlineCallback)
                     case .failTask(let task, let error):
                         return .failTask(task, error)
                     case .unhandledTask:
@@ -228,6 +247,35 @@ extension MQTTChannelHandler {
         }
 
         @usableFromInline
+        enum HitDeadlineAction {
+            case cancelTask(requestID: Int)
+            case reschedule(NIODeadline)
+            case clearCallback
+        }
+
+        @usableFromInline
+        mutating func hitDeadline(now: NIODeadline) -> HitDeadlineAction {
+            switch consume self.state {
+            case .uninitialized:
+                preconditionFailure("Cannot cancel when uninitialized")
+            case .initialized(let state):
+                if let timedOutTask = state.tasks.tasks.min(by: { $0.deadline < $1.deadline }), timedOutTask.deadline <= now {
+                    self = .initialized(state)
+                    return .cancelTask(requestID: timedOutTask.requestID)
+                }
+                if let earliestDeadline = state.tasks.tasks.map({ $0.deadline }).min() {
+                    self = .initialized(state)
+                    return .reschedule(earliestDeadline)
+                }
+                self = .initialized(state)
+                return .clearCallback
+            case .closed:
+                self = .closed
+                return .clearCallback
+            }
+        }
+
+        @usableFromInline
         enum SchedulePingReqAction {
             case schedule(Context)
             case doNothing
@@ -249,7 +297,7 @@ extension MQTTChannelHandler {
 
         @usableFromInline
         enum CancelAction {
-            case failTask(MQTTTask)
+            case failTask(MQTTTask, DeadlineCallbackAction)
             case doNothing
         }
 
@@ -261,9 +309,19 @@ extension MQTTChannelHandler {
                 preconditionFailure("Cannot cancel when uninitialized")
             case .initialized(var state):
                 let cancelledTask = state.cancel(requestID: requestID)
+                let deadlineCallbackAction: DeadlineCallbackAction =
+                    if state.tasks.tasks.isEmpty {
+                        .cancel
+                    } else {
+                        if let earliestDeadline = state.tasks.tasks.map({ $0.deadline }).min() {
+                            .reschedule(earliestDeadline)
+                        } else {
+                            .doNothing
+                        }
+                    }
                 self = .initialized(state)
                 if let cancelledTask {
-                    return .failTask(cancelledTask)
+                    return .failTask(cancelledTask, deadlineCallbackAction)
                 } else {
                     return .doNothing
                 }

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
@@ -23,8 +23,10 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
         func handleScheduledCallback(eventLoop: some NIOCore.EventLoop) {
             let channelHandler = self.channelHandler.value
             switch channelHandler.stateMachine.hitDeadline(now: eventLoop.now) {
-            case .cancelTask(let requestID):
-                channelHandler.cancel(requestID: requestID, error: MQTTError.timeout)
+            case .cancelTasks(let requestIDs):
+                for requestID in requestIDs {
+                    channelHandler.cancel(requestID: requestID, error: MQTTError.timeout)
+                }
             case .reschedule(let deadline):
                 channelHandler.scheduleDeadlineCallback(deadline: deadline)
             case .clearCallback:

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
@@ -13,8 +13,25 @@ import Synchronization
 final class MQTTChannelHandler: ChannelDuplexHandler {
     struct Configuration {
         let pingInterval: TimeAmount?
-        let timeout: TimeAmount?
+        let timeout: TimeAmount
         let version: MQTTConnectionConfiguration.Version
+    }
+
+    struct MQTTDeadlineSchedule: NIOScheduledCallbackHandler {
+        let channelHandler: NIOLoopBound<MQTTChannelHandler>
+
+        func handleScheduledCallback(eventLoop: some NIOCore.EventLoop) {
+            let channelHandler = self.channelHandler.value
+            switch channelHandler.stateMachine.hitDeadline(now: eventLoop.now) {
+            case .cancelTask(let requestID):
+                channelHandler.cancel(requestID: requestID, error: MQTTError.timeout)
+            case .reschedule(let deadline):
+                channelHandler.scheduleDeadlineCallback(deadline: deadline)
+            case .clearCallback:
+                channelHandler.deadlineCallback = nil
+                break
+            }
+        }
     }
 
     typealias InboundIn = ByteBuffer
@@ -26,6 +43,9 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
     @usableFromInline
     var stateMachine: StateMachine<ChannelHandlerContext>
     var session: MQTTSessionStorage
+
+    @usableFromInline
+    private(set) var deadlineCallback: NIOScheduledCallback?
 
     private var decoder: NIOSingleStepByteToMessageProcessor<ByteToMQTTMessageDecoder>
     private let logger: Logger
@@ -52,7 +72,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
         self.logger = logger
 
         self.pingreqTimeout = configuration.pingInterval
-        self.lastPingreqEventTime = .now()
+        self.lastPingreqEventTime = eventLoop.now
         self.pingreqCallback = nil
     }
 
@@ -114,7 +134,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
             promise?.fail(error)
         }
         self.logger.trace("MQTT Out", metadata: ["mqtt_message": .string("\(message)"), "mqtt_packet_id": .string("\(message.packetId)")])
-        self.lastPingreqEventTime = .now()
+        self.lastPingreqEventTime = eventLoop.now
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -137,13 +157,14 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                     )
                     self.respondToPublish(publishMessage, context: context)
                     return
-                case .succeedTask(let task):
+                case .succeedTask(let task, let deadlineAction):
                     if message.type == .PUBREL {
                         self.respondToPubrel(message, context: context)
                     }
-                    task.succeed(message)
+                    self.processDeadlineCallbackAction(action: deadlineAction)
+                    task.promise.succeed(message)
                 case .failTask(let task, let error):
-                    task.fail(error)
+                    task.promise.fail(error)
                 case .unhandledTask:
                     self.processUnhandledPacket(message, context: context)
                 case .closeConnection(let error):
@@ -168,8 +189,9 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
     func cancel(requestID: Int, error: any Error = MQTTError.cancelled) {
         self.eventLoop.assertInEventLoop()
         switch self.stateMachine.cancel(requestID: requestID) {
-        case .failTask(let cancelledTask):
+        case .failTask(let cancelledTask, let deadlineAction):
             cancelledTask.promise.fail(error)
+            self.processDeadlineCallbackAction(action: deadlineAction)
         case .doNothing:
             break
         }
@@ -370,11 +392,11 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
     ) {
         self.eventLoop.assertInEventLoop()
 
+        let deadline = self.eventLoop.now + self.configuration.timeout
         let task = MQTTTask(
             promise: promise,
             requestID: requestID,
-            on: self.eventLoop,
-            timeout: self.configuration.timeout,
+            deadline: deadline,
             checkInbound: checkInbound
         )
 
@@ -383,8 +405,11 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
             context.channel.writeAndFlush(message).assumeIsolated().whenFailure { error in
                 self.cancel(requestID: requestID, error: error)
             }
+            if self.deadlineCallback == nil {
+                self.scheduleDeadlineCallback(deadline: deadline)
+            }
         case .throwError(let error):
-            task.fail(error)
+            task.promise.fail(error)
         }
     }
 
@@ -430,9 +455,30 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
         switch self.stateMachine.close() {
         case .failTasksAndClose(let tasks):
             for task in tasks {
-                task.fail(error)
+                task.promise.fail(error)
             }
             self.session.subscriptions.close(error: error)
+            self.deadlineCallback?.cancel()
+        case .doNothing:
+            break
+        }
+    }
+
+    @usableFromInline
+    func scheduleDeadlineCallback(deadline: NIODeadline) {
+        self.deadlineCallback = try? self.eventLoop.scheduleCallback(
+            at: deadline,
+            handler: MQTTDeadlineSchedule(channelHandler: .init(self, eventLoop: self.eventLoop))
+        )
+    }
+
+    func processDeadlineCallbackAction(action: StateMachine<ChannelHandlerContext>.DeadlineCallbackAction) {
+        switch action {
+        case .cancel:
+            self.deadlineCallback?.cancel()
+            self.deadlineCallback = nil
+        case .reschedule(let deadline):
+            self.scheduleDeadlineCallback(deadline: deadline)
         case .doNothing:
             break
         }
@@ -452,7 +498,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
             case .schedule(let context):
                 // if lastEventTime plus the timeout is less than now send PINGREQ
                 // otherwise reschedule task
-                if channelHandler.lastPingreqEventTime + pingreqTimeout <= .now() {
+                if channelHandler.lastPingreqEventTime + pingreqTimeout <= eventLoop.now {
                     guard context.channel.isActive else { return }
                     channelHandler.sendMessage(
                         MQTTPingreqPacket(),
@@ -470,7 +516,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
                         case .success:
                             break
                         }
-                        channelHandler.lastPingreqEventTime = .now()
+                        channelHandler.lastPingreqEventTime = eventLoop.now
                         channelHandler.schedulePingreqCallback()
                     }
                 } else {
@@ -505,7 +551,7 @@ extension MQTTChannelHandler.Configuration {
             case .disable:
                 nil
             }
-        self.timeout = other.timeout.map(TimeAmount.init)
+        self.timeout = .init(other.timeout)
         self.version = other.version
     }
 }

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTTask.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTTask.swift
@@ -41,34 +41,17 @@ final class MQTTTask {
     let promise: MQTTPromise<any MQTTPacket>
     let checkInbound: (any MQTTPacket) throws -> Bool
     let requestID: Int
-    let timeoutTask: Scheduled<Void>?
+    let deadline: NIODeadline
 
     init(
         promise: MQTTPromise<any MQTTPacket>,
         requestID: Int,
-        on eventLoop: any EventLoop,
-        timeout: TimeAmount?,
+        deadline: NIODeadline,
         checkInbound: @escaping (any MQTTPacket) throws -> Bool
     ) {
         self.promise = promise
         self.checkInbound = checkInbound
         self.requestID = requestID
-        if let timeout {
-            self.timeoutTask = eventLoop.scheduleTask(in: timeout) {
-                promise.fail(MQTTError.timeout)
-            }
-        } else {
-            self.timeoutTask = nil
-        }
-    }
-
-    func succeed(_ response: any MQTTPacket) {
-        self.timeoutTask?.cancel()
-        self.promise.succeed(response)
-    }
-
-    func fail(_ error: any Error) {
-        self.timeoutTask?.cancel()
-        self.promise.fail(error)
+        self.deadline = deadline
     }
 }

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTTask.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTTask.swift
@@ -37,7 +37,7 @@ enum MQTTPromise<T: Sendable>: Sendable {
 }
 
 /// Class encapsulating a single task
-final class MQTTTask {
+struct MQTTTask {
     let promise: MQTTPromise<any MQTTPacket>
     let checkInbound: (any MQTTPacket) throws -> Bool
     let requestID: Int

--- a/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration+ConfigReader.swift
@@ -32,7 +32,7 @@ extension MQTTConnectionConfiguration {
     ///     If the value is an integer, that will be the amount of seconds passed to ``MQTTConnectionConfiguration/PingConfiguration/pingInterval(_:)``.
     ///     For any other value, or if there's no value, the ping configuration will be ``MQTTConnectionConfiguration/PingConfiguration/useServerKeepAlive``.
     /// - `connectTimeout` (int, optional, default: `10`): Timeout for connecting to server, in seconds.
-    /// - `timeout` (int, optional): Timeout for server ACK responses.
+    /// - `timeout` (int, optional, default: `30`): Timeout for server ACK responses.
     /// - `userName` (string, optional): The user identifier used to authenticate against a secured MQTT server.
     /// - `password` (string, optional): The password used to authenticate against a secured MQTT server.
     /// ### TLS configuration keys
@@ -64,7 +64,7 @@ extension MQTTConnectionConfiguration {
         self.keepAliveInterval = config.int(forKey: "keepAliveInterval", as: Duration.self, default: .seconds(90))
         self.pingConfiguration = .init(config: config)
         self.connectTimeout = config.int(forKey: "connectTimeout", as: Duration.self, default: .seconds(10))
-        self.timeout = config.int(forKey: "timeout", as: Duration.self)
+        self.timeout = config.int(forKey: "timeout", as: Duration.self, default: .seconds(30))
         self.userName = config.string(forKey: "userName")
         self.password = config.string(forKey: "password", isSecret: true)
         let tls: Transport.TLS = (try? .init(config: config.scoped(to: "tls"))) ?? .disable

--- a/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration.swift
@@ -238,9 +238,13 @@ public struct MQTTConnectionConfiguration: Sendable {
     /// Configuration for sending `PINGREQ` messages.
     public var pingConfiguration: PingConfiguration
     /// Timeout for connecting to server.
+    ///
+    /// Default value is 10 seconds.
     public var connectTimeout: Duration
     /// Timeout for server response.
-    public var timeout: Duration?
+    ///
+    /// Default value is 30 seconds.
+    public var timeout: Duration
     /// The user identifier used to authenticate against a secured MQTT server.
     public var userName: String?
     /// The password used to authenticate against a secured MQTT server.
@@ -257,8 +261,8 @@ public struct MQTTConnectionConfiguration: Sendable {
     ///   - versionConfiguration: Connection configuration for the version of MQTT server to connect to.
     ///   - keepAliveInterval: MQTT keep alive period.
     ///   - pingConfiguration: Configuration for sending `PINGREQ` messages.
-    ///   - connectTimeout: Timeout for connecting to server.
-    ///   - timeout: Timeout for server ACK responses.
+    ///   - connectTimeout: Timeout for connecting to server. Defaults to 10 seconds.
+    ///   - timeout: Timeout for server ACK responses. Defaults to 30 seconds.
     ///   - userName: The user identifier used to authenticate against a secured MQTT server.
     ///   - password: The password used to authenticate against a secured MQTT server.
     ///   - transport: Transport to use for the connection and its associated configuration.
@@ -267,7 +271,7 @@ public struct MQTTConnectionConfiguration: Sendable {
         keepAliveInterval: Duration = .seconds(90),
         pingConfiguration: PingConfiguration = .useServerKeepAlive,
         connectTimeout: Duration = .seconds(10),
-        timeout: Duration? = nil,
+        timeout: Duration = .seconds(30),
         userName: String? = nil,
         password: String? = nil,
         transport: Transport = .tcp()

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -502,6 +502,34 @@ struct MQTTConnectionTests {
         }
     }
 
+    @Test("Single deadline callback cancels all timed-out Tasks")
+    func timeoutCancelsAllTimedOutRequests() async throws {
+        try await withTestMQTTServer(
+            configuration: .init(timeout: .milliseconds(20))
+        ) { connection in
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    await #expect(throws: MQTTError.timeout) {
+                        try await connection.publish(to: "first", payload: .init(), qos: .atLeastOnce)
+                    }
+                }
+
+                group.addTask {
+                    await #expect(throws: MQTTError.timeout) {
+                        try await connection.publish(to: "second", payload: .init(), qos: .atLeastOnce)
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+        } server: { channel in
+            _ = try await channel.waitForOutboundPacket()
+            _ = try await channel.waitForOutboundPacket()
+
+            await channel.testingEventLoop.advanceTime(by: .milliseconds(25))
+        }
+    }
+
     @Test("Inflight")
     func inflight() async throws {
         let session = MQTTSession(clientID: "inflight")

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -441,6 +441,67 @@ struct MQTTConnectionTests {
         }
     }
 
+    @Test("Timed-out Task is removed before closing Connection")
+    func timeoutClosingConnection() async throws {
+        try await withTestMQTTServer(
+            configuration: .init(timeout: .milliseconds(10))
+        ) { connection in
+            await #expect(throws: MQTTError.timeout) {
+                try await connection.publish(to: "foo", payload: .init(), qos: .atLeastOnce)
+            }
+        } server: { channel in
+            _ = try await channel.waitForOutboundPacket()
+            await channel.testingEventLoop.advanceTime(by: .milliseconds(20))
+        }
+    }
+
+    @Test("Timed-out Task does not fail other in-flight Tasks")
+    func timeoutOnlyCancelsTimedOutRequest() async throws {
+        let (stream, cont) = AsyncStream.makeStream(of: Void.self)
+
+        try await withTestMQTTServer(
+            configuration: .init(timeout: .milliseconds(50))
+        ) { connection in
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    await #expect(throws: MQTTError.timeout) {
+                        try await connection.publish(to: "first", payload: .init(), qos: .atLeastOnce)
+                    }
+                }
+
+                await stream.first { _ in true }
+
+                group.addTask {
+                    await #expect(throws: Never.self) {
+                        try await connection.publish(to: "second", payload: .init(), qos: .atLeastOnce)
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+        } server: { channel in
+            let firstOutbound = try await channel.waitForOutboundPacket()
+            let firstPublish = try MQTTPublishPacket.read(version: .v3_1_1, from: firstOutbound)
+
+            // first request has been waiting for 30ms before the second one is started
+            await channel.testingEventLoop.advanceTime(by: .milliseconds(30))
+
+            cont.yield()
+
+            let secondOutbound = try await channel.waitForOutboundPacket()
+            let secondPublish = try MQTTPublishPacket.read(version: .v3_1_1, from: secondOutbound)
+
+            // after another 30ms, first has waited 60ms total and should time out,
+            // while second has only waited 30ms and is still active
+            await channel.testingEventLoop.advanceTime(by: .milliseconds(30))
+
+            let pubAck = MQTTPubAckPacket(type: .PUBACK, packetId: secondPublish.packetId)
+            try await channel.writeInboundPacket(pubAck, version: .v3_1_1)
+
+            #expect(firstPublish.packetId != secondPublish.packetId)
+        }
+    }
+
     @Test("Inflight")
     func inflight() async throws {
         let session = MQTTSession(clientID: "inflight")


### PR DESCRIPTION
- Switches the implementation of the `MQTTTask` timeout from `scheduleTask` to `NIOScheduledCallbackHandler`
- Fixes the bug reported in #270 by @jollyjinx